### PR TITLE
Make output {T,C}SV format

### DIFF
--- a/canvas_cli/canvas.nw
+++ b/canvas_cli/canvas.nw
@@ -176,7 +176,8 @@ We'll use [[argparse]] to parse the command-line options.
 Remember that we process [[argv]] passed to the function, not [[sys.argv]] 
 directly.
 <<process command-line options>>=
-argp = argparse.ArgumentParser(description="Scriptable Canvas LMS.",
+argp = argparse.ArgumentParser(description="""
+Canvas LMS by command line. Data provided in {T,C}SV format.""",
                                epilog="Web: https://github.com/dbosk/canvasy")
 subp = argp.add_subparsers(required=True)
 <<add arguments>>


### PR DESCRIPTION
Use Python's CSV-writer to write the tab separated output. And add an option to make it comma separated.