### PR TITLE
Makes submission use rich for output (fixes #71)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -79,6 +79,17 @@ python-versions = ">=3.6.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "commonmark"
+version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+
+[[package]]
 name = "cryptography"
 version = "38.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -201,6 +212,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pygments"
+version = "2.14.0"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+plugins = ["importlib-metadata"]
+
+[[package]]
 name = "pypandoc"
 version = "1.10"
 description = "Thin wrapper for pandoc."
@@ -254,6 +276,22 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rich"
+version = "13.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[package.dependencies]
+commonmark = ">=0.9.0,<0.10.0"
+pygments = ">=2.6.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
+
+[[package]]
 name = "secretstorage"
 version = "3.3.3"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -272,6 +310,14 @@ description = "Python 2 and 3 compatibility utilities"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
@@ -301,7 +347,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "76e27cd046a588ceee46d6debd01728f03e0181822a5d2043c013f5620d5a677"
+content-hash = "84281c69b6aa90be727f49f48526839b8e47e4e76517906fef81f8fda4dd75d6"
 
 [metadata.files]
 appdirs = [
@@ -321,6 +367,7 @@ canvasapi = []
 certifi = []
 cffi = []
 charset-normalizer = []
+commonmark = []
 cryptography = []
 idna = []
 importlib-metadata = []
@@ -336,6 +383,7 @@ pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
+pygments = []
 pypandoc = []
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -347,10 +395,12 @@ pywin32-ctypes = [
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
 ]
 requests = []
+rich = []
 secretstorage = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
+typing-extensions = []
 urllib3 = []
 zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ canvasapi = "<3.0.0"
 keyring = "^23.11.0"
 pypandoc = "^1.10"
 arrow = "^1.2.3"
+rich = "^13.0.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -15,9 +15,11 @@ import canvaslms.hacks.canvasapi
 import argparse
 import csv
 import json
-import pydoc
+import os
 import pypandoc
 import re
+import rich.console
+import rich.markdown
 import sys
 import urllib.request
 
@@ -149,10 +151,38 @@ def submission_command(config, canvas, args):
   <<get and print the submission data>>
 @
 
-Then we can fetch the submission.
+Then we can fetch the submission, format it to markdown ([[format_submission]]) 
+and then print it.
+We use the [[rich]] package to print it.
+This prints the markdown output of [[format_submission]] nicer in the terminal.
+It also adds syntax highlighting for the source code attachments.
+However, we need to adapt the use of styles to the pager to be used.
 <<get and print the submission data>>=
+console = rich.console.Console()
 for submission in submission_list:
-  pydoc.pager(format_submission(submission))
+  <<check if we should use styles>>
+  with console.pager(styles=styles):
+    console.print(rich.markdown.Markdown(format_submission(submission)))
+@
+
+\subsection{Check if we should use styles}
+
+By default, [[rich.console.Console]] uses the [[pydoc.pager]], which uses the 
+system pager (as determined by environment variables etc.).
+The default usually can't handle colours, so [[rich]] doesn't use colours when 
+paging.
+We want to check if [[less -r]] or [[less -R]] is set as the pager, in that 
+case we can use styles.
+<<check if we should use styles>>=
+pager = ""
+if "MANPAGER" in os.environ:
+  pager = os.environ["MANPAGER"]
+elif "PAGER" in os.environ:
+  pager = os.environ["PAGER"]
+
+styles = False
+if "less" in pager and ("-R" in pager or "-r" in pager):
+  styles = True
 @
 
 
@@ -376,16 +406,28 @@ except AttributeError:
 
 \subsection{Attachments}
 
+For the attachment, we want to add it as a Markdown code block.
+This means that we can set what type of data the code block contains.
+We compute this text from the content type of the attachment.
+For instance, Python source code is [[text/x-python]].
+We remove the [[text/]] prefix and check if there is any [[x-]] prefix left, in 
+which case we remove that as well.
 <<add attachments to output>>=
 try:
   for attachment in submission.attachments:
     if "text/" not in attachment["content-type"]:
       continue
 
-    contents = urllib.request.urlopen(attachment["url"]).read().decode("utf-8")
+    content_type = attachment["content-type"][len("text/"):]
+    if content_type.startswith("x-"):
+      content_type = content_type[2:]
+
+    contents = urllib.request.urlopen(attachment["url"]).read().decode("utf8")
+
     formatted_submission += format_section(
       attachment["filename"],
-      f"```\n{contents}\n```")
+      f"```{content_type}\n{contents}\n```"
+    )
 except AttributeError:
   pass
 @


### PR DESCRIPTION
Before, the output of the submission command was markdown in the
terminal. Now it puts that markdown through rich. This adds syntax
highlighting for the code.
