### PR TITLE
Adds verbose option to `grade` command

### DIFF
--- a/src/canvaslms/cli/grade.nw
+++ b/src/canvaslms/cli/grade.nw
@@ -49,10 +49,13 @@ We introduce two options:
 This can be almost anything: Canvas accepts points, percentages or letter 
 grades and will convert accordingly.
 \item [[-m]] or [[--message]], which sets a comment.
+\item [[-v]] or [[--verbose]], which will cause [[canvaslms]] to print what 
+grade is set for which assignment and which student.
 \end{itemize}
-Both options are optional.
+Both [[-g]] and [[-m]] are optional.
 If neither is given, the SpeedGrader page of each submission is opened in the 
 web browser.
+In that case, [[-v]] make not much sense.
 <<set up options for grading>>=
 grade_options = grade_parser.add_argument_group(
   "arguments to set the grade and/or comment, "
@@ -83,6 +86,34 @@ if not args.grade and not args.message:
     webbrowser.open(submissions.speedgrader(submission))
 else:
   for submission in submission_list:
+    <<if verbose, print [[submission]] and [[results]] to stdout>>
     submission.edit(**results)
 @
+
+\subsection{Verbose output when setting grades}
+
+Now, we want a verbosity option to control whether or not to print what's 
+happening (even for non-errors).
+Using the option turns verbose mode on, it's off by default.
+<<set up options for grading>>=
+grade_parser.add_argument("-v", "--verbose",
+  action="store_true", default=False,
+  help="Increases verbosity, prints what grade is set "
+       "for which assignment for which student.")
+<<if verbose, print [[submission]] and [[results]] to stdout>>=
+if args.verbose:
+  id = f"{submission.assignment.course.course_code} " \
+       f"{submission.assignment.name} {submission.user}"
+
+  event = ""
+  try:
+    event += f" grade = {args.grade}"
+  except:
+    pass
+  try:
+    event += f" msg = '{args.message}'"
+  except:
+    pass
+
+  print(f"{id}:{event}")
 


### PR DESCRIPTION
This is a step towards the wish of @alba-kth to have verbose output when 
writing (i.e. setting grades). It's an option, default is still silent. But at 
least now there is an option.
