### PR TITLE
Bugfix: `disjunctmax.grade_max` had `not` in the wrong place

### DIFF
--- a/src/canvaslms/grades/disjunctmax.nw
+++ b/src/canvaslms/grades/disjunctmax.nw
@@ -104,16 +104,17 @@ def summarize(user, assignments_list):
 \subsection{Computing the maximum}
 
 To compute the maximum for the A--E grades; we will convert the grades into 
-integers, compute the maximum, round the value to an integer and convert back.
+integers, compute the maximum, and convert back.
 We also include P/F here, since we can count them as lower than A--E.
 <<helper functions>>=
 def grade_max(grades):
   """Takes a list of A--E/P--F grades, returns the maximum."""
-  num_grades = list(map(grade_to_int,
-                        filter(lambda x: x[0] != "F", grades)))
-  if not num_grades:
+  num_grades = list(map(grade_to_int, grades))
+
+  if num_grades:
     max_grade = max(num_grades)
     return int_to_grade(max_grade)
+
   return None
 
 def grade_to_int(grade):
@@ -127,5 +128,4 @@ def int_to_grade(int_grade):
                    0: "P",
                    1: "E", 2: "D", 3: "C", 4: "B", 5: "A"}
   return grade_map_inv[int_grade]
-@
 


### PR DESCRIPTION
There was a `not` where it shouldn't have been. This resulted in results never being reported.