### PR TITLE
Adds missing `cli` in import statement

### DIFF
--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -10,7 +10,7 @@ import canvasapi.exceptions
 import canvasapi.file
 import canvasapi.submission
 
-import canvaslms
+import canvaslms.cli
 import canvaslms.cli.assignments as assignments
 import canvaslms.cli.users as users
 import canvaslms.hacks.canvasapi
@@ -755,8 +755,8 @@ def resolve_grader(submission):
   try:
     return submission.assignment.course.get_user(submission.grader_id)
   except canvasapi.exceptions.ResourceDoesNotExist:
-    canvaslms.warn(f"unknown grader {submission.grader_id} "
-                   f"for submission {submission}.")
+    canvaslms.cli.warn(f"unknown grader {submission.grader_id} "
+                       f"for submission {submission}.")
     return f"unknown grader {submission.grader_id}"
 @
 


### PR DESCRIPTION
The `warn` function is not available in the `canvaslms` module, but in
the `canvaslms.cli` module. This commit fixes the import statement to
import the `warn` function from the correct module.
