### PR TITLE
clean up messages

### DIFF
--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -760,8 +760,6 @@ def resolve_grader(submission):
   try:
     return submission.assignment.course.get_user(submission.grader_id)
   except canvasapi.exceptions.ResourceDoesNotExist:
-    canvaslms.cli.warn(f"unknown grader {submission.grader_id} "
-                       f"for submission {submission}.")
     return f"unknown grader {submission.grader_id}"
 @
 

--- a/src/canvaslms/grades/tilkryLAB1.nw
+++ b/src/canvaslms/grades/tilkryLAB1.nw
@@ -265,7 +265,6 @@ elif grade not in "PF":
 mandatory.append(grade)
 <<handle missing submission>>=
 if not is_optional(assignment):
-  logging.warning(f"No submission for {user} in {assignment}, using F")
   mandatory.append("F")
 @
 


### PR DESCRIPTION
- Don't write unknown grader warning to stderr
- Don't warn whenever a student has no submission

This improves the situation for cronjobs.
