### PR TITLE
improve submission caching

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,6 +14,7 @@ canvaslms.pdf: canvaslms.tex
 canvaslms.pdf: didactic.sty
 
 canvaslms.pdf: ${SRC_DIR}/hacks/canvasapi.tex
+canvaslms.pdf: ${SRC_DIR}/hacks/attachment_cache.tex
 canvaslms.pdf: ${SRC_DIR}/cli/cli.tex
 canvaslms.pdf: ${SRC_DIR}/cli/login.tex
 canvaslms.pdf: ${SRC_DIR}/cli/courses.tex

--- a/doc/canvaslms.tex
+++ b/doc/canvaslms.tex
@@ -90,6 +90,7 @@ def command_function(config, canvas, args):
 \part{Some hacks}
 
 \input{../src/canvaslms/hacks/canvasapi.tex}
+\input{../src/canvaslms/hacks/attachment_cache.tex}
 
 \part{The command-line interface}
 

--- a/src/canvaslms/cli/assignments.nw
+++ b/src/canvaslms/cli/assignments.nw
@@ -30,6 +30,7 @@ import canvasapi
 import canvaslms.cli
 import canvaslms.cli.courses as courses
 import canvaslms.cli.modules as modules
+import canvaslms.cli.submissions as submissions
 import canvaslms.cli.utils
 import canvaslms.hacks.canvasapi
 import csv
@@ -639,14 +640,30 @@ We provide the following functions:
 \begin{itemize}
   \item [[list_assignments]], which returns all assignments;
   \item [[list_ungraded_assignments]], which returns all ungraded assignments;
-  \item [[filter_assignments]], which returns all assignments whose title 
+  \item [[filter_assignments]], which returns all assignments whose title
   matches a regular expression.
 \end{itemize}
-We return the assignments for a list of courses, since we can match several 
+We return the assignments for a list of courses, since we can match several
 courses with a regular expression (using [[filter_courses]]).
+
+For [[list_ungraded_assignments]], we filter locally rather than using Canvas's
+[[bucket="ungraded"]] parameter.
+This avoids cache inconsistencies (the caching system doesn't track the bucket
+parameter).
+The filtering logic checks each assignment for ungraded submissions by
+examining [[submitted_at]], [[graded_at]], and
+[[grade_matches_current_submission]] attributes using the
+[[submissions.is_submission_ungraded]] helper function.
+While this requires fetching submission data, the [[LazySubmission]] wrapper
+and caching system minimize API calls.
+
+Note that we set [[assignment.course]] and [[assignment.assignment_group]] for
+\emph{all} assignments before filtering.
+This ensures that all assignments in the cache have these attributes set
+consistently, regardless of which filtering path is used to access them later.
 <<functions>>=
 def list_assignments(assignments_containers, ungraded=False):
-  """Lists all assignments in all assignments containers (courses or 
+  """Lists all assignments in all assignments containers (courses or
   assignement groups)"""
   for container in assignments_containers:
     if isinstance(container, canvasapi.course.Course):
@@ -655,10 +672,7 @@ def list_assignments(assignments_containers, ungraded=False):
       assignment_group = container
       course = assignment_group.course
 
-    if ungraded:
-      assignments = container.get_assignments(bucket="ungraded")
-    else:
-      assignments = container.get_assignments()
+    assignments = container.get_assignments()
 
     for assignment in assignments:
       try:
@@ -670,6 +684,15 @@ def list_assignments(assignments_containers, ungraded=False):
         assignment.assignment_group = assignment_group
       except NameError:
         pass
+
+      if ungraded:
+        has_ungraded = False
+        for submission in assignment.get_submissions():
+          if submissions.is_submission_ungraded(submission):
+            has_ungraded = True
+            break
+        if not has_ungraded:
+          continue
 
       yield assignment
 

--- a/src/canvaslms/cli/assignments.nw
+++ b/src/canvaslms/cli/assignments.nw
@@ -35,12 +35,15 @@ import canvaslms.cli.utils
 import canvaslms.hacks.canvasapi
 import csv
 import json
+import logging
 import os
 import pypandoc
 import re
 import rich.console
 import rich.markdown
 import sys
+
+logger = logging.getLogger(__name__)
 
 <<functions>>
 
@@ -777,8 +780,7 @@ assignment_data = {}
 <<parse lock date argument>>
 
 if not assignment_data:
-  print("No date options provided. Use --due-at, --unlock-at, or --lock-at.", 
-        file=sys.stderr)
+  logger.error("No date options provided. Use --due-at, --unlock-at, or --lock-at.")
   return
 
 # Wrap the assignment data in the structure Canvas expects
@@ -796,21 +798,21 @@ if args.due_at is not None:
   try:
     assignment_data['due_at'] = canvaslms.cli.utils.parse_date(args.due_at)
   except ValueError as e:
-    print(f"Error parsing due date: {e}", file=sys.stderr)
+    logger.error(f"Error parsing due date: {e}")
     return
 <<parse unlock date argument>>=
 if args.unlock_at is not None:
   try:
     assignment_data['unlock_at'] = canvaslms.cli.utils.parse_date(args.unlock_at)
   except ValueError as e:
-    print(f"Error parsing unlock date: {e}", file=sys.stderr)
+    logger.error(f"Error parsing unlock date: {e}")
     return
 <<parse lock date argument>>=
 if args.lock_at is not None:
   try:
     assignment_data['lock_at'] = canvaslms.cli.utils.parse_date(args.lock_at)
   except ValueError as e:
-    print(f"Error parsing lock date: {e}", file=sys.stderr)
+    logger.error(f"Error parsing lock date: {e}")
     return
 @
 
@@ -820,19 +822,17 @@ Finally, we iterate through the selected assignments and update their dates
 using the Canvas API.
 <<update assignment dates>>=
 for assignment in assignment_list:
-  if args.verbose:
-    print(f"Updating assignment '{assignment.name}' (ID: {assignment.id})")
-    for field, value in assignment_data.items():
-      if value is None:
-        print(f"  Clearing {field}")
-      else:
-        print(f"  Setting {field} to {value}")
-  
+  logger.debug(f"Updating assignment '{assignment.name}' (ID: {assignment.id})")
+  for field, value in assignment_data.items():
+    if value is None:
+      logger.debug(f"  Clearing {field}")
+    else:
+      logger.debug(f"  Setting {field} to {value}")
+
   try:
     assignment.edit(**updates)
-    if not args.verbose:
-      print(f"Updated dates for assignment '{assignment.name}'")
+    logger.info(f"Updated dates for assignment '{assignment.name}'")
   except Exception as e:
-    print(f"Error updating assignment '{assignment.name}' (ID: {assignment.id}): {e}", file=sys.stderr)
+    logger.error(f"Error updating assignment '{assignment.name}' (ID: {assignment.id}): {e}")
 @
 

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -112,19 +112,35 @@ If the cache directory doesn't exist, we create it first.
 def save_canvas_cache(canvas, token, hostname):
   """Saves the Canvas object to encrypted cache"""
   try:
+    import time
+    save_start = time.perf_counter()
+
     # Derive encryption key
     key = derive_key(token, hostname)
     fernet = Fernet(key)
 
     # Pickle and encrypt
+    pickle_start = time.perf_counter()
     pickled = pickle.dumps(canvas)
+    pickle_elapsed = time.perf_counter() - pickle_start
+    pickle_size = len(pickled)
+
+    encrypt_start = time.perf_counter()
     encrypted = fernet.encrypt(pickled)
+    encrypt_elapsed = time.perf_counter() - encrypt_start
 
     # Write to cache file
     cache_path = get_cache_path(hostname)
     <<create cache directory if needed>>
+    write_start = time.perf_counter()
     with open(cache_path, "wb") as f:
       f.write(encrypted)
+    write_elapsed = time.perf_counter() - write_start
+
+    save_elapsed = time.perf_counter() - save_start
+    logger.debug(f"Canvas cache save: {save_elapsed:.2f}s total "
+                 f"(pickle: {pickle_elapsed:.2f}s/{pickle_size/1024:.1f}KB, "
+                 f"encrypt: {encrypt_elapsed:.2f}s, write: {write_elapsed:.2f}s)")
   except Exception:
     # If saving fails, silently continue
     # (cache is optional, don't break the command)
@@ -160,17 +176,33 @@ In all these cases, the correct behavior is to create a fresh Canvas object.
 def load_canvas_cache(token, hostname):
   """Loads the Canvas object from encrypted cache, returns None if unavailable"""
   try:
+    import time
+    load_start = time.perf_counter()
+
     # Derive encryption key
     key = derive_key(token, hostname)
     fernet = Fernet(key)
 
     # Read and decrypt
     cache_path = get_cache_path(hostname)
+    read_start = time.perf_counter()
     with open(cache_path, "rb") as f:
       encrypted = f.read()
+    read_elapsed = time.perf_counter() - read_start
+    encrypted_size = len(encrypted)
 
+    decrypt_start = time.perf_counter()
     pickled = fernet.decrypt(encrypted)
+    decrypt_elapsed = time.perf_counter() - decrypt_start
+
+    unpickle_start = time.perf_counter()
     canvas = pickle.loads(pickled)
+    unpickle_elapsed = time.perf_counter() - unpickle_start
+
+    load_elapsed = time.perf_counter() - load_start
+    logger.debug(f"Canvas cache load: {load_elapsed:.2f}s total "
+                 f"(read: {read_elapsed:.2f}s/{encrypted_size/1024:.1f}KB, "
+                 f"decrypt: {decrypt_elapsed:.2f}s, unpickle: {unpickle_elapsed:.2f}s)")
 
     return canvas
   except (FileNotFoundError, InvalidToken, pickle.UnpicklingError, Exception):

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -231,8 +231,22 @@ This forces a fresh fetch of all Canvas data on the next run.
 <<add cache clear subcommand>>=
 clear_parser = cache_subp.add_parser(
   "clear",
-  help="Clear the cached Canvas data"
-)
+  help="Clear the cached Canvas data",
+  description="""
+  Removes the encrypted Canvas object cache which stores previously fetched
+  courses, assignments, users, and submissions. This forces a fresh fetch of
+  all Canvas data on the next command run.
+
+  The Canvas object cache is encrypted using your Canvas access token and stored
+  in a platform-specific cache directory. Clearing it is useful when:
+  - Canvas data has changed and you want to force a refresh
+  - The cache has become corrupted
+  - You want to free disk space
+  - You've changed Canvas tokens
+
+  Note: This does NOT remove cached attachment files. Use 'cache clear-attachments'
+  for that purpose.
+  """)
 clear_parser.set_defaults(func=clear_command)
 @
 

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -1,4 +1,4 @@
-\chapter{Cache persistence}
+\chapter{Cache persistence and management}
 
 We want to persist the Canvas object between runs to avoid redundant API calls.
 The Canvas object contains cached data for courses, assignments, users, and
@@ -10,6 +10,9 @@ However, the Canvas object contains sensitive data (course information, student
 data, etc.), so we must encrypt it before storing to disk.
 We use authenticated encryption to ensure both confidentiality and integrity.
 
+Additionally, we cache submission attachments to avoid re-downloading files.
+This is managed separately from the Canvas object cache.
+
 \section{Design overview}
 
 The cache persistence mechanism works as follows:
@@ -19,7 +22,7 @@ The cache persistence mechanism works as follows:
 \item If not, we create a new Canvas object from the API.
 \item After each command completes, we save the Canvas object to the cache.
 \item The cache is stored in the user's cache directory (from [[appdirs]]).
-\item We provide a [[cache clear]] subcommand to explicitly remove the cache.
+\item We provide [[cache clear]] and [[cache clear-attachments]] subcommands.
 \end{enumerate}
 
 The key derivation works as follows:
@@ -41,6 +44,8 @@ import hashlib
 import os
 import pickle
 import pathlib
+
+import canvaslms.hacks.attachment_cache as attachment_cache
 
 dirs = appdirs.AppDirs("canvaslms", "dbosk@kth.se")
 
@@ -187,21 +192,24 @@ def clear_cache(hostname):
 @
 
 
-\subsection{The cache command}
+\section{The cache command and subcommands}
 
-The [[cache]] subcommand provides control over the cache.
-Currently, it only supports [[clear]], but we could add other operations in the
-future (e.g., [[cache status]] to show cache size and age).
+The [[cache]] command provides control over the various caches.
+We provide subcommands for different cache management operations:
+\begin{description}
+\item[[cache clear]] Clears the encrypted Canvas object cache
+\item[[cache clear-attachments]] Removes old cached attachment files
+\end{description}
+
 <<functions>>=
 def add_command(subp):
   """Adds the cache command to argparse parser"""
   cache_parser = subp.add_parser(
     "cache",
-    help="Manage the Canvas object cache",
+    help="Manage caches",
     description="""
-Manages the persistent cache of Canvas data. The cache stores previously
-fetched courses, assignments, users, and submissions to speed up subsequent
-commands. The cache is encrypted using your Canvas token.
+Manages the persistent caches used by canvaslms. This includes the encrypted
+Canvas object cache and the attachment file cache.
 """
   )
 
@@ -211,13 +219,24 @@ commands. The cache is encrypted using your Canvas token.
     required=True
   )
 
-  # cache clear command
-  clear_parser = cache_subp.add_parser(
-    "clear",
-    help="Clear the cached Canvas data"
-  )
-  clear_parser.set_defaults(func=clear_command)
+  <<add cache clear subcommand>>
+  <<add cache clear-attachments subcommand>>
+@
 
+\subsection{The cache clear subcommand}
+
+The [[cache clear]] subcommand removes the encrypted Canvas object cache.
+This forces a fresh fetch of all Canvas data on the next run.
+
+<<add cache clear subcommand>>=
+clear_parser = cache_subp.add_parser(
+  "clear",
+  help="Clear the cached Canvas data"
+)
+clear_parser.set_defaults(func=clear_command)
+@
+
+<<functions>>=
 def clear_command(config, canvas, args):
   """Clears the Canvas cache"""
   import canvaslms.cli.login
@@ -235,3 +254,84 @@ def clear_command(config, canvas, args):
   else:
     print(f"No cache found for {hostname}")
 @
+
+\subsection{The cache clear-attachments subcommand}
+
+The [[cache clear-attachments]] subcommand removes cached attachment files that
+haven't been accessed recently.
+This helps manage disk space without requiring users to manually locate and
+delete cache files.
+
+The subcommand accepts an [[--older-than-days]] option (default: 90 days) to
+control how aggressively files are removed.
+A shorter period frees more space but requires more re-downloads; a longer
+period keeps more files but uses more disk space.
+
+<<add cache clear-attachments subcommand>>=
+clear_attachments_parser = cache_subp.add_parser("clear-attachments",
+  help="Remove old cached attachment files",
+  description="""
+  Removes cached attachment files that haven't been accessed in the specified
+  number of days. This helps manage disk space while keeping frequently-used
+  files available.
+
+  Cached attachments are stored in a platform-specific cache directory and use
+  content-addressed storage (files are identified by SHA-256 hash). This means
+  identical files submitted by different students or in different submission
+  versions are stored only once.
+
+  The cleanup process:
+  1. Identifies attachments not accessed within the time window
+  2. Removes their index entries
+  3. Removes orphaned data files no longer referenced by any index entry
+  4. Reports statistics about files removed and space freed
+  """)
+clear_attachments_parser.add_argument("--older-than-days",
+  type=int,
+  default=90,
+  help="Remove files not accessed in this many days (default: 90)")
+clear_attachments_parser.set_defaults(func=clear_attachments_command)
+@
+
+<<functions>>=
+def clear_attachments_command(config, canvas, args):
+  """Removes old cached attachments and reports statistics"""
+  max_age = args.older_than_days
+
+  print(f"Removing cached attachments not accessed in {max_age} days...")
+
+  stats = attachment_cache.cleanup_old_attachments(max_age_days=max_age)
+
+  files_removed = stats["files_removed"]
+  bytes_freed = stats["bytes_freed"]
+
+  # Convert bytes to human-readable format
+  if bytes_freed < 1024:
+    size_str = f"{bytes_freed} bytes"
+  elif bytes_freed < 1024 * 1024:
+    size_str = f"{bytes_freed / 1024:.1f} KB"
+  elif bytes_freed < 1024 * 1024 * 1024:
+    size_str = f"{bytes_freed / (1024 * 1024):.1f} MB"
+  else:
+    size_str = f"{bytes_freed / (1024 * 1024 * 1024):.2f} GB"
+
+  if files_removed == 0:
+    print(f"No files older than {max_age} days found.")
+  else:
+    print(f"Removed {files_removed} file(s), freed {size_str}.")
+@
+
+\section{Future extensions}
+
+This module can be extended with additional cache management commands:
+
+\begin{description}
+\item[[cache stats]] Display statistics about cache usage (number of files,
+  total size, oldest/newest files)
+\item[[cache list]] List all cached attachments with details
+\item[[cache clear-all]] Remove all caches (attachments, pickles, etc.)
+\item[[cache show-location]] Display the cache directory path
+\end{description}
+
+The subcommand structure makes these additions straightforward---just add new
+subparsers in new chunks.

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -41,12 +41,14 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.fernet import Fernet, InvalidToken
 import hashlib
+import logging
 import os
 import pickle
 import pathlib
 
 import canvaslms.hacks.attachment_cache as attachment_cache
 
+logger = logging.getLogger(__name__)
 dirs = appdirs.AppDirs("canvaslms", "dbosk@kth.se")
 
 <<functions>>
@@ -264,9 +266,9 @@ def clear_command(config, canvas, args):
     hostname = f"https://{hostname}"
 
   if clear_cache(hostname):
-    print(f"Cache cleared for {hostname}")
+    logger.info(f"Cache cleared for {hostname}")
   else:
-    print(f"No cache found for {hostname}")
+    logger.info(f"No cache found for {hostname}")
 @
 
 \subsection{The cache clear-attachments subcommand}
@@ -312,7 +314,7 @@ def clear_attachments_command(config, canvas, args):
   """Removes old cached attachments and reports statistics"""
   max_age = args.older_than_days
 
-  print(f"Removing cached attachments not accessed in {max_age} days...")
+  logger.info(f"Removing cached attachments not accessed in {max_age} days...")
 
   stats = attachment_cache.cleanup_old_attachments(max_age_days=max_age)
 
@@ -330,9 +332,9 @@ def clear_attachments_command(config, canvas, args):
     size_str = f"{bytes_freed / (1024 * 1024 * 1024):.2f} GB"
 
   if files_removed == 0:
-    print(f"No files older than {max_age} days found.")
+    logger.info(f"No files older than {max_age} days found.")
   else:
-    print(f"Removed {files_removed} file(s), freed {size_str}.")
+    logger.info(f"Removed {files_removed} file(s), freed {size_str}.")
 @
 
 \section{Future extensions}

--- a/src/canvaslms/cli/cli.nw
+++ b/src/canvaslms/cli/cli.nw
@@ -43,6 +43,7 @@ from urllib3.util.retry import Retry
 
 <<modules>>
 
+logger = logging.getLogger(__name__)
 dirs = appdirs.AppDirs("canvaslms", "dbosk@kth.se")
 
 <<classes and exceptions>>
@@ -62,19 +63,22 @@ class EmptyListError(Exception):
   pass
 @
 
-We will use the function [[err]] for errors and [[warn]] for warnings, both 
+We will use the function [[err]] for errors and [[warn]] for warnings, both
 inspired by err(3) and warn(3) in the BSD world.
 These will be available as [[canvaslms.cli.err]] and [[canvaslms.cli.warn]].
+
+These functions now use Python's logging module internally, so all error and
+warning messages benefit from proper logging infrastructure (levels, formatting,
+redirection).
 <<functions>>=
 def err(rc, msg):
-  """Prints msg to stderr, prints a stack trace and
-  exits with rc as return code"""
-  print(f"{sys.argv[0]}: error: {msg}", file=sys.stderr)
+  """Logs error msg and exits with rc as return code"""
+  logger.error(f"{sys.argv[0]}: {msg}")
   sys.exit(rc)
 
 def warn(msg):
-  """Prints msg to stderr"""
-  print(f"{sys.argv[0]}: {msg}", file=sys.stderr)
+  """Logs warning msg"""
+  logger.warning(f"{sys.argv[0]}: {msg}")
 @
 
 

--- a/src/canvaslms/cli/cli.nw
+++ b/src/canvaslms/cli/cli.nw
@@ -34,6 +34,7 @@ import argcomplete, argparse
 from canvasapi import Canvas
 import canvaslms.cli.login
 import json
+import logging
 import os
 import pathlib
 import sys
@@ -166,9 +167,22 @@ subp = argp.add_subparsers(
 argcomplete.autocomplete(argp)
 args = argp.parse_args()
 
+<<configure logging based on verbose flag>>
+
 config = read_configuration(args.config_file)
 
 <<run subcommands>>
+@
+
+We configure Python's logging module based on the [[-v]]/[[--verbose]] flag.
+When verbose mode is enabled, we set the logging level to [[INFO]] so that
+diagnostic messages from the caching system and other modules are visible.
+Without the flag, we only show [[WARNING]] and above.
+<<configure logging based on verbose flag>>=
+if args.verbose:
+  logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+else:
+  logging.basicConfig(level=logging.WARNING, format='[%(levelname)s] %(message)s')
 @
 
 
@@ -198,6 +212,9 @@ argp.add_argument("-d", "--delimiter",
 argp.add_argument("-q", "--quiet",
   action="store_true",
   help="Suppress error messages, report only exit codes")
+argp.add_argument("-v", "--verbose",
+  action="store_true",
+  help="Enable verbose output and logging")
 @
 
 

--- a/src/canvaslms/cli/discussions.nw
+++ b/src/canvaslms/cli/discussions.nw
@@ -86,6 +86,7 @@ import subprocess
 import sys
 import tempfile
 import csv
+import logging
 import pypandoc
 import rich.console
 import rich.markdown
@@ -94,6 +95,8 @@ import yaml
 import canvaslms.cli.courses
 import canvaslms.cli.utils
 import canvaslms.cli.calendar
+
+logger = logging.getLogger(__name__)
 
 <<functions>>
 
@@ -197,21 +200,19 @@ The main function that processes the announce command.
 <<functions>>=
 def announce_command(config, canvas, args):
   """Posts announcements to matching courses"""
-  
+
   # Get list of matching courses
   course_list = list(canvaslms.cli.courses.filter_courses(canvas, args.course))
-  
+
   if not course_list:
-    print(f"No courses found matching pattern: {args.course}", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"No courses found matching pattern: {args.course}")
   
   # Get the message content and attributes
   if args.interactive:
     # In interactive mode, parse YAML front matter
     result = get_announcement_from_editor(args.title)
     if result is None:
-      print("Editor cancelled or failed.", file=sys.stderr)
-      sys.exit(1)
+      canvaslms.cli.err(1, "Editor cancelled or failed.")
     
     attributes, message = result
     title = attributes.get('title', args.title)
@@ -233,8 +234,7 @@ def announce_command(config, canvas, args):
         # Re-open editor with current content
         result = get_announcement_from_editor(None, attributes, message)
         if result is None:
-          print("Editor cancelled or failed.", file=sys.stderr)
-          sys.exit(1)
+          canvaslms.cli.err(1, "Editor cancelled or failed.")
         attributes, message = result
         title = attributes.get('title')
       elif choice in ['d', 'discard', 'cancel']:
@@ -245,18 +245,15 @@ def announce_command(config, canvas, args):
         
   elif args.message:
     if not args.title:
-      print("Error: Title is required when using -m/--message", file=sys.stderr)
-      sys.exit(1)
+      canvaslms.cli.err(1, "Title is required when using -m/--message")
     title = args.title
     message = args.message
     attributes = {}
   else:
-    print("Error: Either provide -m/--message or use -i/--interactive mode", file=sys.stderr)
-    sys.exit(1)
-  
+    canvaslms.cli.err(1, "Either provide -m/--message or use -i/--interactive mode")
+
   if not message.strip():
-    print("Error: Message cannot be empty", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, "Message cannot be empty")
   
   # Show courses that will receive the announcement
   print(f"Will post announcement '{title}' to {len(course_list)} course(s):", file=sys.stderr)
@@ -276,8 +273,7 @@ def announce_command(config, canvas, args):
   try:
     html_message = pypandoc.convert_text(message, 'html', format='md')
   except Exception as e:
-    print(f"Warning: Failed to convert markdown to HTML: {e}", file=sys.stderr)
-    print("Using raw content instead.", file=sys.stderr)
+    logger.warning(f"Failed to convert markdown to HTML: {e}. Using raw content instead.")
     html_message = message
   
   # Post announcements
@@ -288,7 +284,7 @@ def announce_command(config, canvas, args):
       <<post announcement to course>>
       success_count += 1
     except Exception as e:
-      print(f"Failed to post to {course.course_code}: {course.name} - {str(e)}", file=sys.stderr)
+      logger.error(f"Failed to post to {course.course_code}: {course.name} - {str(e)}")
       failed_count += 1
   
   # Only output result if there were failures
@@ -304,13 +300,12 @@ Output is in CSV format for easy parsing with POSIX tools.
 <<functions>>=
 def list_command(config, canvas, args):
   """Lists discussions or announcements from matching courses"""
-  
+
   # Get list of matching courses
   course_list = list(canvaslms.cli.courses.filter_courses(canvas, args.course))
-  
+
   if not course_list:
-    print(f"No courses found matching pattern: {args.course}", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"No courses found matching pattern: {args.course}")
   
   # List discussions/announcements for each course
   for course in course_list:
@@ -320,8 +315,7 @@ def list_command(config, canvas, args):
       else:  # discussions
         <<list discussions for course>>
     except Exception as e:
-      print(f"Error accessing {course.course_code}: {str(e)}", file=sys.stderr)
-      sys.exit(1)
+      canvaslms.cli.err(1, f"Error accessing {course.course_code}: {str(e)}")
 @
 
 \section{The show command function}
@@ -330,13 +324,12 @@ The main function that processes the show command.
 <<functions>>=
 def show_command(config, canvas, args):
   """Shows detailed view of discussions or announcements from matching courses"""
-  
+
   # Get list of matching courses
   course_list = list(canvaslms.cli.courses.filter_courses(canvas, args.course))
-  
+
   if not course_list:
-    print(f"No courses found matching pattern: {args.course}", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"No courses found matching pattern: {args.course}")
   
   <<compile regex patterns for show>>
   
@@ -355,10 +348,10 @@ def show_command(config, canvas, args):
       for item in items:
         item._course = course
         all_items.append(item)
-        
+
+
     except Exception as e:
-      print(f"Error accessing {course.course_code}: {str(e)}", file=sys.stderr)
-      sys.exit(1)
+      canvaslms.cli.err(1, f"Error accessing {course.course_code}: {str(e)}")
   
   # Filter by regex if provided
   filtered_items = []
@@ -378,8 +371,7 @@ def show_command(config, canvas, args):
   selected_items = filtered_items[:count]
   
   if not selected_items:
-    print(f"No matching {args.type} found", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"No matching {args.type} found")
   
   # Display items using Rich
   console = rich.console.Console()
@@ -433,7 +425,7 @@ def parse_yaml_front_matter(content):
     message_content = parts[2].lstrip('\n')
     return attributes, message_content
   except yaml.YAMLError as e:
-    print(f"Warning: Failed to parse YAML front matter: {e}", file=sys.stderr)
+    logger.warning(f"Failed to parse YAML front matter: {e}")
     return {}, content
 
 def format_yaml_front_matter(attributes, message_content):
@@ -512,13 +504,13 @@ def get_announcement_from_editor(initial_title=None, initial_attributes=None, in
     try:
       subprocess.run([editor, temp_file_path], check=True)
     except subprocess.CalledProcessError as e:
-      print(f"Error: Editor exited with error code {e.returncode}", file=sys.stderr)
+      logger.error(f"Editor exited with error code {e.returncode}")
       return None
     except FileNotFoundError:
-      print(f"Error: Editor '{editor}' not found", file=sys.stderr)
+      logger.error(f"Editor '{editor}' not found")
       return None
     except Exception as e:
-      print(f"Error opening editor: {e}", file=sys.stderr)
+      logger.error(f"Error opening editor: {e}")
       return None
     
     # Read the content back
@@ -686,8 +678,7 @@ def parse_date_attribute(attributes, attr_name):
     try:
       return canvaslms.cli.utils.format_canvas_time(date_value)
     except Exception as e:
-      print(f"Warning: Failed to parse {attr_name} '{date_value}': {e}",
-            file=sys.stderr)
+      logger.warning(f"Failed to parse {attr_name} '{date_value}': {e}")
       return None
   return None
 @
@@ -772,8 +763,7 @@ if args.match:
     flags = re.IGNORECASE if args.ignore_case else 0
     pattern = re.compile(args.match, flags)
   except re.error as e:
-    print(f"Invalid regex for --match: {e}", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"Invalid regex for --match: {e}")
 
 title_pattern = None
 if args.title:
@@ -781,8 +771,7 @@ if args.title:
     flags = re.IGNORECASE if args.ignore_case else 0
     title_pattern = re.compile(args.title, flags)
   except re.error as e:
-    print(f"Invalid regex for --title: {e}", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"Invalid regex for --title: {e}")
 
 message_pattern = None
 if args.message:
@@ -790,8 +779,7 @@ if args.message:
     flags = re.IGNORECASE if args.ignore_case else 0
     message_pattern = re.compile(args.message, flags)
   except re.error as e:
-    print(f"Invalid regex for --message: {e}", file=sys.stderr)
-    sys.exit(1)
+    canvaslms.cli.err(1, f"Invalid regex for --message: {e}")
 @
 
 <<functions>>=

--- a/src/canvaslms/cli/quizzes.nw
+++ b/src/canvaslms/cli/quizzes.nw
@@ -854,10 +854,12 @@ try:
     report = quiz.create_report(report_type='student_analysis', includes_all_versions=True)
   except AttributeError:
     # Quiz doesn't support create_report, fall back to manual export
-    print(f"Note: Canvas API quiz data processing is limited for this quiz type.")
-    print(f"For best results, export the Student Analysis Report as CSV and use --csv option.")
-    print(f"\nTo export: Go to Quiz -> ... menu -> Student Analysis")
-    print(f"Download the CSV and run: canvaslms quizzes analyse --csv <file.csv>")
+    canvaslms.cli.warn(
+      "Canvas API quiz data processing is limited for this quiz type.\n"
+      "For best results, export the Student Analysis Report as CSV and use --csv option.\n"
+      "\nTo export: Go to Quiz -> ... menu -> Student Analysis\n"
+      "Download the CSV and run: canvaslms quizzes analyse --csv <file.csv>"
+    )
     sys.exit(0)
   
   # Poll until the report is ready
@@ -908,16 +910,20 @@ try:
     canvaslms.cli.err(1, "Report file URL not available")
 except AttributeError:
   # Quiz doesn't support the report API
-  print(f"Note: Canvas API quiz data processing is limited for this quiz type.")
-  print(f"For best results, export the Student Analysis Report as CSV and use --csv option.")
-  print(f"\nTo export: Go to Quiz -> ... menu -> Student Analysis")
-  print(f"Download the CSV and run: canvaslms quizzes analyse --csv <file.csv>")
+  canvaslms.cli.warn(
+    "Canvas API quiz data processing is limited for this quiz type.\n"
+    "For best results, export the Student Analysis Report as CSV and use --csv option.\n"
+    "\nTo export: Go to Quiz -> ... menu -> Student Analysis\n"
+    "Download the CSV and run: canvaslms quizzes analyse --csv <file.csv>"
+  )
   sys.exit(0)
 except Exception as e:
-  canvaslms.cli.warn(f"Could not fetch quiz report via API: {e}")
-  print(f"\nNote: For best results, export the Student Analysis Report as CSV manually.")
-  print(f"To export: Go to Quiz -> ... menu -> Student Analysis")
-  print(f"Download the CSV and run: canvaslms quizzes analyse --csv <file.csv>")
+  canvaslms.cli.warn(
+    f"Could not fetch quiz report via API: {e}\n"
+    "\nNote: For best results, export the Student Analysis Report as CSV manually.\n"
+    "To export: Go to Quiz -> ... menu -> Student Analysis\n"
+    "Download the CSV and run: canvaslms quizzes analyse --csv <file.csv>"
+  )
   sys.exit(1)
 @
 

--- a/src/canvaslms/cli/results.nw
+++ b/src/canvaslms/cli/results.nw
@@ -542,6 +542,9 @@ For each assignment that a student is not done with, we yield a tuple of the
 user, the assignment and the reason why the assignment is missing.
 
 The reason can be "not submitted" or "not graded" or "not a passing grade".
+We use [[submissions.is_submission_ungraded]] to detect when a student has
+resubmitted after receiving a failing grade, ensuring we catch cases where
+the grade doesn't match the current submission (not just timestamp comparisons).
 
 The only reason to use a different module is if you have optional assignments.
 We only want to remind the students of the things they need to pass the course.
@@ -564,8 +567,7 @@ elif submission.grade is None:
   else:
     yield user, assignment, "not done"
 elif not filter_grade(submission.grade, passing_regex):
-  if submission.submitted_at and \
-        submission.submitted_at > submission.graded_at:
+  if submissions.is_submission_ungraded(submission):
     yield user, assignment, \
           f"not a passing grade ({submission.grade}), resubmission not graded"
   else:

--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -223,7 +223,9 @@ if args.history:
 if args.ungraded:
   submissions = list_ungraded_submissions(assignment_list, include=to_include)
 else:
-  submissions = list_submissions(assignment_list, include=to_include)
+  # Enable bulk refresh when no filters will be applied (accessing all submissions)
+  check_bulk = not (args.user or args.category or args.group)
+  submissions = list_submissions(assignment_list, include=to_include, check_bulk_refresh=check_bulk)
 <<add options for history>>=
 list_parser.add_argument("-H", "--history", action="store_true",
   help="Include submission history.")
@@ -843,16 +845,16 @@ def is_submission_ungraded(submission):
 @
 
 <<functions>>=
-def list_submissions(assignments, include=["submission_comments"]):
+def list_submissions(assignments, include=["submission_comments"], check_bulk_refresh=False):
   for assignment in assignments:
-    submissions = assignment.get_submissions(include=include)
+    submissions = assignment.get_submissions(include=include, check_bulk_refresh=check_bulk_refresh)
     for submission in submissions:
       submission.assignment = assignment
       yield submission
 
 def list_ungraded_submissions(assignments, include=["submisson_comments"]):
   for assignment in assignments:
-    submissions = assignment.get_submissions(include=include)
+    submissions = assignment.get_submissions(include=include, check_bulk_refresh=True)
     for submission in submissions:
       submission.assignment = assignment
       if is_submission_ungraded(submission):

--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -768,8 +768,80 @@ We provide the following functions:
   \item [[list_submissions]], which returns all submissions;
   \item [[list_ungraded_submissions]], which returns all ungraded submissions.
 \end{itemize}
-We return the submissions for a list of assignments, since we can match several 
+We return the submissions for a list of assignments, since we can match several
 assignments with a regular expression (using [[filter_assignments]]).
+
+\subsection{Filtering strategy for ungraded submissions}
+\label{SubmissionsFiltering}
+
+Canvas provides a [[bucket="ungraded"]] parameter to filter submissions
+server-side.
+However, using this parameter causes cache inconsistencies: the caching system
+in [[canvasapi.nw]] doesn't track the [[bucket]] parameter, leading to
+incorrect results when mixing calls with and without this parameter.
+
+Instead, we always fetch all submissions and filter locally.
+This approach:
+\begin{itemize}
+\item Ensures cache correctness---no ambiguity in cache keys.
+\item Maintains lazy-loading performance---the [[LazySubmission]] wrapper only
+refreshes accessed items.
+\item Simplifies the caching logic---no need to track the bucket parameter.
+\end{itemize}
+
+A submission is considered ungraded if:
+\begin{itemize}
+\item It has been submitted ([[submitted_at]] is not [[None]]).
+\item AND either:
+  \begin{itemize}
+  \item It has never been graded ([[graded_at is None]]), or
+  \item The grade doesn't match the current submission
+([[not grade_matches_current_submission]])---this occurs when a student
+resubmits after receiving a grade.
+  \end{itemize}
+\end{itemize}
+
+This local filtering logic matches Canvas's server-side [[bucket="ungraded"]]
+behavior while avoiding cache consistency issues.
+
+Note that we set [[submission.assignment]] for \emph{all} submissions, not just
+those we yield.
+This ensures that all submissions in the cache have this attribute set
+consistently, regardless of which filtering path is used to access them later.
+
+\subsection{Helper function to check if a submission is ungraded}
+
+The logic for determining whether a submission is ungraded is used in multiple
+places throughout the codebase.
+We extract it into a helper function to maintain consistency and avoid code
+duplication.
+
+This function implements the filtering strategy described above
+(\cref{SubmissionsFiltering}), encapsulating the logic so it can be reused
+by other modules (such as [[assignments.nw]] and [[results.nw]]).
+<<functions>>=
+def is_submission_ungraded(submission):
+    """
+    Returns True if the submission is ungraded or needs regrading.
+
+    A submission is considered ungraded if:
+    - It has been submitted (submitted_at is not None), AND
+    - Either it has never been graded (graded_at is None), OR
+    - The grade doesn't match the current submission (not
+      grade_matches_current_submission) -- this occurs when a student
+      resubmits after receiving a grade.
+
+    Parameters:
+        submission: A Canvas Submission object
+
+    Returns:
+        bool: True if the submission needs grading, False otherwise
+    """
+    return (submission.submitted_at and
+            (submission.graded_at is None or
+             not submission.grade_matches_current_submission))
+@
+
 <<functions>>=
 def list_submissions(assignments, include=["submission_comments"]):
   for assignment in assignments:
@@ -780,12 +852,10 @@ def list_submissions(assignments, include=["submission_comments"]):
 
 def list_ungraded_submissions(assignments, include=["submisson_comments"]):
   for assignment in assignments:
-    submissions = assignment.get_submissions(bucket="ungraded",
-      include=include)
+    submissions = assignment.get_submissions(include=include)
     for submission in submissions:
-      if submission.submitted_at and (submission.graded_at is None or
-          not submission.grade_matches_current_submission):
-        submission.assignment = assignment
+      submission.assignment = assignment
+      if is_submission_ungraded(submission):
         yield submission
 @
 

--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -26,6 +26,7 @@ import canvaslms.cli.assignments as assignments
 import canvaslms.cli.users as users
 import canvaslms.cli.utils
 import canvaslms.hacks.canvasapi
+import canvaslms.hacks.attachment_cache as attachment_cache
 
 import argparse
 import csv
@@ -1168,10 +1169,30 @@ def convert_to_md(attachment: canvasapi.file.File,
 contents = convert_to_md(attachment, tmpdir)
 @
 
-The download is simple.
+We check if the attachment is already cached before downloading.
+If cached, we copy from the cache to avoid redundant network requests.
+Otherwise, we download the file and add it to the cache.
+
+This is particularly important for computing diffs between submission versions:
+if a student submits version N+1, we already have the attachments from versions
+N, N-1, \ldots cached locally, so we only need to download version N+1.
+
 <<download [[attachment]] to [[outfile]] in [[tmpdir]]>>=
 outfile = tmpdir / attachment.filename
-attachment.download(outfile)
+cached_path = attachment_cache.get_cached_attachment(attachment.id)
+
+if cached_path:
+  # Use cached file - copy to temporary directory for processing
+  import shutil
+  shutil.copy(cached_path, outfile)
+else:
+  # Download and cache for future use
+  attachment.download(outfile)
+  attachment_cache.cache_attachment(attachment.id, outfile, {
+    'filename': attachment.filename,
+    'size': getattr(attachment, 'size', 0),
+    'content_type': getattr(attachment, 'content-type', 'application/octet-stream')
+  })
 @
 
 If the content type is text, we can just decode it and use it in a Markdown 

--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -32,6 +32,7 @@ import argparse
 import csv
 <<import [[difflib]]>>
 import json
+import logging
 import os
 import pathlib
 import subprocess
@@ -46,6 +47,8 @@ import tempfile
 import textwrap
 import urllib.request
 import webbrowser
+
+logger = logging.getLogger(__name__)
 
 <<constants>>
 <<functions>>
@@ -2175,15 +2178,16 @@ else:
 
 \subsection{Verbose output when setting grades}
 
-If verbose mode is enabled, we want to print out what's happening.
+We log grading operations at DEBUG level, which is controlled by the [[-v]]
+flag. This provides detailed feedback about what's happening during grading
+operations without cluttering normal output.
 <<if verbose, print [[submission]] and [[results]] to stdout>>=
-if args.verbose:
-  print(f"Grading {submission.assignment.course.course_code} "
-        f"{submission.assignment.name} for {submission.user.name}")
-  if args.grade:
-    print(f"  Setting grade to: {args.grade}")
-  if args.message:
-    print(f"  Adding comment: {args.message}")
+logger.debug(f"Grading {submission.assignment.course.course_code} "
+             f"{submission.assignment.name} for {submission.user.name}")
+if args.grade:
+  logger.debug(f"  Setting grade to: {args.grade}")
+if args.message:
+  logger.debug(f"  Adding comment: {args.message}")
 @
 
 \subsection{Error handling for grading operations}

--- a/src/canvaslms/hacks/Makefile
+++ b/src/canvaslms/hacks/Makefile
@@ -4,6 +4,7 @@ NOTANGLEFLAGS.py=
 .PHONY: all
 all: __init__.py
 all: canvasapi.py canvasapi.tex
+all: attachment_cache.py attachment_cache.tex
 
 canvasapi.py: canvasapi.nw
 	${NOTANGLE.py}
@@ -11,6 +12,7 @@ canvasapi.py: canvasapi.nw
 .PHONY: clean
 clean:
 	${RM} canvasapi.py canvasapi.tex
+	${RM} attachment_cache.py attachment_cache.tex
 
 
 INCLUDE_MAKEFILES=../../../makefiles

--- a/src/canvaslms/hacks/Makefile
+++ b/src/canvaslms/hacks/Makefile
@@ -9,6 +9,15 @@ all: attachment_cache.py attachment_cache.tex
 canvasapi.py: canvasapi.nw
 	${NOTANGLE.py}
 
+attachment-cache.py: attachment_cache.nw
+	${NOTANGLE.py}
+
+.INTERMEDIATE: attachment-cache.py
+
+attachment_cache.py: attachment-cache.py
+	${MV} $< $@
+
+
 .PHONY: clean
 clean:
 	${RM} canvasapi.py canvasapi.tex

--- a/src/canvaslms/hacks/attachment_cache.nw
+++ b/src/canvaslms/hacks/attachment_cache.nw
@@ -1,0 +1,268 @@
+\chapter{Caching submission attachments}
+
+When working with submission attachments, we want to avoid downloading the same
+file multiple times.
+This is particularly important when computing diffs between submission
+versions: if a student submits version N+1, we already have the attachments
+from versions N, N-1, \ldots cached locally.
+Computing the new diff then only requires downloading version N+1.
+
+\section{Design decisions}
+
+We face several design choices for caching attachment files:
+
+\subsection{Where to store cached files}
+
+We use a platform-specific cache directory provided by the [[appdirs]] package.
+This follows the conventions of the host operating system:
+\begin{itemize}
+\item Linux: [[~/.cache/canvaslms/attachments/]]
+\item macOS: [[~/Library/Caches/canvaslms/attachments/]]
+\item Windows: [[C:\Users\<user>\AppData\Local\canvaslms\attachments\]]
+\end{itemize}
+
+This is superior to storing files in the pickle cache because:
+\begin{itemize}
+\item Pickle files remain small (metadata only)
+\item Users can manage cache size and location using OS tools
+\item Cache cleanup doesn't affect submission metadata
+\end{itemize}
+
+\subsection{Content-addressed storage}
+
+We use \emph{content-addressed storage}: files are identified by the SHA-256
+hash of their content, not by Canvas attachment ID or filename.
+This provides perfect deduplication---if multiple students submit the same
+file, or if a student resubmits an unchanged file, we store it only once.
+
+The storage structure is:
+\begin{description}
+\item[Content files] [[<cache_dir>/attachments/<sha256>.dat]]
+\item[Metadata index] [[<cache_dir>/attachments/index.json]] mapping attachment
+  IDs to hashes
+\end{description}
+
+The index maps Canvas attachment IDs to cached file metadata:
+\begin{minted}{python}
+{
+  "12345": {
+    "hash": "a1b2c3...",
+    "filename": "report.pdf",
+    "size": 102400,
+    "content_type": "application/pdf",
+    "last_access": "2025-11-24T10:30:00"
+  }
+}
+\end{minted}
+
+\subsection{When attachments become stale}
+
+Attachments for a particular submission version are immutable---once submitted,
+they never change.
+Therefore, we cache attachment files forever (no time-to-live expiration).
+
+The only cleanup is \emph{age-based}: we remove files that haven't been
+accessed in a configurable number of days (default: 90 days).
+This prevents unbounded cache growth while keeping frequently-used files.
+
+\section{Implementation}
+
+<<attachment_cache.py>>=
+"""Content-addressed cache for Canvas submission attachments"""
+
+import appdirs
+import hashlib
+import json
+import pathlib
+import shutil
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+
+<<cache directory initialization>>
+<<cache operations>>
+@
+
+\subsection{Cache directory initialization}
+
+We use [[appdirs]] to get the platform-specific cache directory, and create the
+necessary subdirectories on first use.
+
+<<cache directory initialization>>=
+CACHE_DIR = pathlib.Path(appdirs.user_cache_dir("canvaslms")) / "attachments"
+INDEX_FILE = CACHE_DIR / "index.json"
+
+def _ensure_cache_dir():
+    """Create cache directory if it doesn't exist"""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+def _load_index() -> Dict[str, Dict[str, Any]]:
+    """Load the metadata index from disk"""
+    _ensure_cache_dir()
+    if INDEX_FILE.exists():
+        with open(INDEX_FILE, 'r') as f:
+            return json.load(f)
+    return {}
+
+def _save_index(index: Dict[str, Dict[str, Any]]):
+    """Save the metadata index to disk"""
+    _ensure_cache_dir()
+    with open(INDEX_FILE, 'w') as f:
+        json.dump(index, f, indent=2)
+@
+
+\subsection{Computing content hashes}
+
+We use SHA-256 to compute content hashes because it provides:
+\begin{itemize}
+\item Strong collision resistance (extremely unlikely two different files hash
+  to the same value)
+\item Reasonable performance for typical attachment sizes
+\item Wide availability in Python's standard library
+\end{itemize}
+
+<<cache operations>>=
+def _compute_hash(file_path: pathlib.Path) -> str:
+    """Compute SHA-256 hash of file content"""
+    sha256 = hashlib.sha256()
+    with open(file_path, 'rb') as f:
+        while chunk := f.read(8192):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+@
+
+\subsection{Retrieving cached attachments}
+
+When we need an attachment, we first check if it's in the cache.
+If found, we update the [[last_access]] timestamp to prevent premature cleanup,
+and return the path to the cached file.
+
+<<cache operations>>=
+def get_cached_attachment(attachment_id: int) -> Optional[pathlib.Path]:
+    """
+    Get cached file path for attachment, or None if not cached.
+
+    Updates last_access timestamp on cache hit.
+    """
+    index = _load_index()
+    attachment_key = str(attachment_id)
+
+    if attachment_key not in index:
+        return None
+
+    entry = index[attachment_key]
+    file_hash = entry["hash"]
+    cached_file = CACHE_DIR / f"{file_hash}.dat"
+
+    if not cached_file.exists():
+        # Index entry exists but file missing - remove stale entry
+        del index[attachment_key]
+        _save_index(index)
+        return None
+
+    # Update last access time
+    entry["last_access"] = datetime.now().isoformat()
+    _save_index(index)
+
+    return cached_file
+@
+
+\subsection{Caching new attachments}
+
+When we download a new attachment, we compute its hash, store the file by hash,
+and update the index.
+If a file with the same hash already exists (deduplication), we reuse it.
+
+<<cache operations>>=
+def cache_attachment(attachment_id: int, file_path: pathlib.Path,
+                     metadata: Dict[str, Any]):
+    """
+    Cache an attachment file using content-addressed storage.
+
+    Args:
+        attachment_id: Canvas attachment ID
+        file_path: Path to the downloaded file
+        metadata: Dictionary with 'filename', 'size', 'content_type'
+    """
+    _ensure_cache_dir()
+
+    # Compute content hash
+    file_hash = _compute_hash(file_path)
+    cached_file = CACHE_DIR / f"{file_hash}.dat"
+
+    # Copy file to cache if not already present (deduplication)
+    if not cached_file.exists():
+        shutil.copy2(file_path, cached_file)
+
+    # Update index
+    index = _load_index()
+    index[str(attachment_id)] = {
+        "hash": file_hash,
+        "filename": metadata.get("filename", "unknown"),
+        "size": metadata.get("size", 0),
+        "content_type": metadata.get("content_type", "application/octet-stream"),
+        "last_access": datetime.now().isoformat()
+    }
+    _save_index(index)
+@
+
+\subsection{Cache cleanup}
+
+We provide a cleanup function that removes files not accessed within a
+specified time window.
+This allows users to manage cache size manually via the [[canvaslms cache
+clear-attachments]] command.
+
+The cleanup process:
+\begin{enumerate}
+\item Load the index and identify attachments not accessed recently
+\item Remove their index entries
+\item Find all [[.dat]] files in the cache directory
+\item Build a set of hashes still referenced by the index
+\item Remove [[.dat]] files whose hashes aren't referenced (orphaned files)
+\item Report statistics about removed files and space freed
+\end{enumerate}
+
+<<cache operations>>=
+def cleanup_old_attachments(max_age_days: int = 90) -> Dict[str, Any]:
+    """
+    Remove cached attachments not accessed in max_age_days.
+
+    Returns:
+        Dictionary with 'files_removed' and 'bytes_freed' statistics
+    """
+    _ensure_cache_dir()
+    index = _load_index()
+    cutoff_date = datetime.now() - timedelta(days=max_age_days)
+
+    # Find attachments to remove from index
+    to_remove = []
+    for attachment_id, entry in index.items():
+        last_access = datetime.fromisoformat(entry["last_access"])
+        if last_access < cutoff_date:
+            to_remove.append(attachment_id)
+
+    # Remove old entries from index
+    for attachment_id in to_remove:
+        del index[attachment_id]
+    _save_index(index)
+
+    # Build set of hashes still referenced
+    referenced_hashes = {entry["hash"] for entry in index.values()}
+
+    # Find and remove orphaned .dat files
+    files_removed = 0
+    bytes_freed = 0
+
+    for dat_file in CACHE_DIR.glob("*.dat"):
+        file_hash = dat_file.stem  # filename without extension
+        if file_hash not in referenced_hashes:
+            file_size = dat_file.stat().st_size
+            dat_file.unlink()
+            files_removed += 1
+            bytes_freed += file_size
+
+    return {
+        "files_removed": files_removed,
+        "bytes_freed": bytes_freed
+    }
+@

--- a/src/canvaslms/hacks/attachment_cache.nw
+++ b/src/canvaslms/hacks/attachment_cache.nw
@@ -67,7 +67,7 @@ This prevents unbounded cache growth while keeping frequently-used files.
 
 \section{Implementation}
 
-<<attachment_cache.py>>=
+<<attachment-cache.py>>=
 """Content-addressed cache for Canvas submission attachments"""
 
 import appdirs

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1023,55 +1023,153 @@ class LazySubmission:
     submission = object.__getattribute__(self, '_submission')
     return str(submission)
 
-  def __getstate__(self):
-    """
-    Prepare object for pickling.
+  <<pickle support for LazySubmission>>
+@
 
-    We can't pickle method references, so we exclude _original_get_submission.
-    It will be restored from the assignment object during unpickling.
-    """
-    state = {
-      '_submission': object.__getattribute__(self, '_submission'),
-      '_assignment': object.__getattribute__(self, '_assignment'),
-      '_includes': object.__getattribute__(self, '_includes'),
-      '_last_refresh': object.__getattribute__(self, '_last_refresh'),
-    }
-    return state
+\subsubsection{Pickle support for cache persistence}
 
-  def __setstate__(self, state):
-    """
-    Restore object after unpickling.
+The \texttt{LazySubmission} wrapper must support pickling to enable cache
+persistence.
+When the \texttt{Canvas} object is saved to disk (see cache.nw), Python's
+\texttt{pickle} module serializes the entire object hierarchy, including all
+cached submissions.
 
-    Restore all attributes from state, and reconstruct _original_get_submission
-    by finding it in the decorator's closure.
-    """
-    for key, value in state.items():
-      object.__setattr__(self, key, value)
+\paragraph{The pickling challenge}
 
-    # Restore the original method from the assignment's decorated method
-    # The decorated method has the original in its closure
-    assignment = state['_assignment']
-    decorated_method = assignment.__class__.get_submission
+Python's \texttt{pickle} cannot serialize certain objects, including:
+\begin{itemize}
+\item Function and method references (unless they're module-level functions)
+\item Lambda functions
+\item Generator objects
+\item Objects with circular references to unpicklable objects
+\end{itemize}
 
-    # The original method is captured in the decorator's closure
-    # We can access it via the closure of the decorated method
-    # The decorated method's __closure__ contains the original method
-    try:
-      # Find the original_get_submission in the closure
-      for cell in decorated_method.__closure__:
-        try:
-          obj = cell.cell_contents
-          # Check if it's a callable with the right name
-          if callable(obj) and hasattr(obj, '__name__') and \
-             'get_submission' in obj.__name__:
-            object.__setattr__(self, '_original_get_submission', obj)
-            break
-        except (AttributeError, ValueError):
-          continue
-    except (AttributeError, TypeError):
-      # If we can't find it in closure, fall back to None
-      # This means refresh won't work, but at least unpickling succeeds
-      object.__setattr__(self, '_original_get_submission', None)
+Our \texttt{LazySubmission} stores \texttt{\_original\_get\_submission}, which is
+a reference to the original (unwrapped) \texttt{get\_submission} method.
+This is a \emph{bound method} when called, but we store the \emph{unbound
+function} from the decorator's closure.
+Method objects are not picklable by default.
+
+\paragraph{The solution: reconstruct from closure}
+
+We implement \texttt{\_\_getstate\_\_} and \texttt{\_\_setstate\_\_} to handle
+pickling:
+\begin{enumerate}
+\item \textbf{Before pickling} (\texttt{\_\_getstate\_\_}): Exclude the
+  unpicklable \texttt{\_original\_get\_submission} from the state dictionary.
+  Save only the submission, assignment reference, includes list, and last
+  refresh timestamp.
+\item \textbf{After unpickling} (\texttt{\_\_setstate\_\_}): Reconstruct
+  \texttt{\_original\_get\_submission} by searching the decorator's closure.
+  The decorated method stores the original in its \texttt{\_\_closure\_\_}
+  attribute, which we can access via
+  \texttt{assignment.\_\_class\_\_.get\_submission}.
+\end{enumerate}
+
+\paragraph{Why closure search works}
+
+When the \texttt{cache\_submissions} decorator wraps
+\texttt{Assignment.get\_submission}, it captures the original method in a
+closure variable (line~1072 in the decorator):
+\begin{minted}{python}
+original_get_submission = cls.get_submission
+\end{minted}
+
+This variable is referenced by the \texttt{new\_get\_submission} function,
+making it part of the function's closure.
+After unpickling, we can access this closure via the class's decorated method.
+
+\paragraph{Limitations and failure modes}
+
+This approach has several limitations:
+\begin{description}
+\item[Version compatibility] If the decorator implementation changes between
+  pickle and unpickle (e.g., code upgrade), the closure structure may differ,
+  causing reconstruction to fail.
+\item[Closure ambiguity] If multiple callable objects exist in the closure with
+  \enquote{get\_submission} in their name, we might retrieve the wrong one.
+  The heuristic checks for callables with matching names.
+\item[Graceful degradation] If reconstruction fails, we set
+  \texttt{\_original\_get\_submission} to \texttt{None}.
+  The wrapper remains functional for read-only access (attributes pass through
+  to the wrapped submission), but calling \texttt{\_refresh()} will fail.
+  This is acceptable because:
+  \begin{itemize}
+  \item Cache files are typically invalidated on code changes
+  \item The user can clear the cache manually if issues arise
+  \item Better to have stale data than a complete crash
+  \end{itemize}
+\end{description}
+
+\paragraph{Alternative approaches considered}
+
+We considered but rejected these alternatives:
+\begin{description}
+\item[Storing method name as string] Reconstruct via \texttt{getattr(assignment,
+  'get\_submission')}.
+  Problem: This retrieves the \emph{decorated} method, not the original,
+  causing infinite recursion or double-wrapping.
+\item[Not using a wrapper] Store a \enquote{needs refresh} flag on the
+  submission itself.
+  Problem: Mutating Canvas API objects is fragile and breaks the lazy-loading
+  design.
+\item[Store assignment ID, re-fetch assignment] Reconstruct the entire context
+  from IDs.
+  Problem: Defeats the purpose of caching; would require API calls just to
+  restore cache state.
+\end{description}
+
+Now we implement the pickle support:
+<<pickle support for LazySubmission>>=
+def __getstate__(self):
+  """
+  Prepare object for pickling.
+
+  We can't pickle method references, so we exclude _original_get_submission.
+  It will be restored from the decorator's closure during unpickling.
+  """
+  state = {
+    '_submission': object.__getattribute__(self, '_submission'),
+    '_assignment': object.__getattribute__(self, '_assignment'),
+    '_includes': object.__getattribute__(self, '_includes'),
+    '_last_refresh': object.__getattribute__(self, '_last_refresh'),
+  }
+  return state
+
+def __setstate__(self, state):
+  """
+  Restore object after unpickling.
+
+  Restore all attributes from state, and reconstruct _original_get_submission
+  by searching the decorator's closure for the original method.
+  """
+  for key, value in state.items():
+    object.__setattr__(self, key, value)
+
+  # Restore the original method from the assignment's decorated method
+  # The decorated method has the original in its closure
+  assignment = state['_assignment']
+  decorated_method = assignment.__class__.get_submission
+
+  # The original method is captured in the decorator's closure
+  # We can access it via the closure of the decorated method
+  # The decorated method's __closure__ contains the original method
+  try:
+    # Find the original_get_submission in the closure
+    for cell in decorated_method.__closure__:
+      try:
+        obj = cell.cell_contents
+        # Check if it's a callable with the right name
+        if callable(obj) and hasattr(obj, '__name__') and \
+           'get_submission' in obj.__name__:
+          object.__setattr__(self, '_original_get_submission', obj)
+          break
+      except (AttributeError, ValueError):
+        continue
+  except (AttributeError, TypeError):
+    # If we can't find it in closure, fall back to None
+    # This means refresh won't work, but at least unpickling succeeds
+    object.__setattr__(self, '_original_get_submission', None)
 @
 
 This class is used by the caching decorator below.

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -978,6 +978,9 @@ class LazySubmission:
 
   def _refresh(self):
     """Refresh the wrapped submission from Canvas."""
+    import time
+    refresh_start = time.perf_counter()
+
     assignment = object.__getattribute__(self, '_assignment')
     submission = object.__getattribute__(self, '_submission')
     includes = object.__getattribute__(self, '_includes')
@@ -993,6 +996,9 @@ class LazySubmission:
     # Update internal state (cache automatically updated via reference)
     object.__setattr__(self, '_submission', fresh_submission)
     object.__setattr__(self, '_last_refresh', datetime.now())
+
+    refresh_elapsed = time.perf_counter() - refresh_start
+    logger.debug(f"Individual refresh: user_id={submission.user_id} in {refresh_elapsed:.2f}s")
 
   def __getattribute__(self, name):
     """
@@ -1524,6 +1530,8 @@ if total_count > 0:
 
   # If threshold exceeded, perform bulk refresh
   if stale_count >= threshold:
+    import time
+    bulk_start = time.perf_counter()
     logger.info(f"Bulk refresh: {stale_count}/{total_count} submissions stale, "
                 f"threshold={threshold}")
 
@@ -1534,7 +1542,10 @@ if total_count > 0:
     all_includes |= to_include
 
     # Perform bulk refresh (1 API call)
+    api_start = time.perf_counter()
+    submission_count = 0
     for raw_submission in get_submissions(self, include=list(all_includes)):
+      submission_count += 1
       if raw_submission.user_id in self.__cache:
         # Update existing wrapper in-place
         lazy_submission = self.__cache[raw_submission.user_id]
@@ -1546,7 +1557,11 @@ if total_count > 0:
         lazy_submission = LazySubmission(raw_submission, self, all_includes,
                                        original_get_submission)
         self.__cache[raw_submission.user_id] = lazy_submission
+    api_elapsed = time.perf_counter() - api_start
 
     self.__all_fetched = datetime.now()
+    bulk_elapsed = time.perf_counter() - bulk_start
+    logger.debug(f"Bulk refresh completed: {submission_count} submissions in {bulk_elapsed:.2f}s "
+                 f"(API: {api_elapsed:.2f}s, processing: {bulk_elapsed - api_elapsed:.2f}s)")
 @
 

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1185,6 +1185,29 @@ We can only get submission from an assignment object.
 We can either get all submissions, or one specific submission if we specify the
 user.
 
+Canvas's [[get_submissions()]] method accepts a [[bucket]] parameter to filter
+submissions server-side (e.g., [[bucket="ungraded"]]).
+However, this caching implementation does not track the [[bucket]] parameter in
+the cache key.
+
+This is intentional: tracking [[bucket]] would require separate caches for
+different bucket values, complicating the cache hierarchy and potentially
+causing inconsistencies.
+Instead, client code (particularly [[submissions.nw]] and [[assignments.nw]])
+performs local filtering on the complete submission list.
+
+This design ensures:
+\begin{itemize}
+\item Cache keys are unambiguous (based only on user ID).
+\item Lazy loading works correctly (submissions refresh based on staleness, not
+bucket parameter).
+\item Cache hierarchy is preserved (course caches contain assignment caches
+contain submission caches).
+\end{itemize}
+
+See \cref{SubmissionsFiltering} in [[submissions.nw]] for the local filtering
+implementation.
+
 Now we combine the caching mechanism with lazy loading.
 The cache stores \texttt{LazySubmission} wrappers instead of raw submissions.
 This means submissions are only refreshed when their attributes are actually

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -833,13 +833,214 @@ def make_course_groups_cacheable():
 @
 
 
+\subsection{Lazy-loading submissions}
+
+The current caching approach has an inefficiency: when we call
+\texttt{get\_submissions()}, we immediately check if each cached submission needs
+updating and refresh it if necessary.
+However, in many workflows we filter the submission list to access only a few
+submissions (e.g., filtering by user or assignment).
+This means we waste API calls refreshing submissions we never actually use.
+
+\subsubsection{Contrasting eager and lazy loading}
+
+Consider this usage pattern:
+\begin{minted}{python}
+submissions = assignment.get_submissions()
+filtered = [s for s in submissions if s.user_id == target_user]
+print(filtered[0].grade)
+\end{minted}
+
+With \emph{eager loading} (the old approach):
+\begin{enumerate}
+\item \texttt{get\_submissions()} returns 50 cached submissions
+\item We check each submission: is it stale? Does it need refresh?
+\item We make 50 API calls to refresh non-final grades
+\item We filter to 1 submission
+\item We access the grade (already fresh)
+\end{enumerate}
+
+With \emph{lazy loading} (the new approach):
+\begin{enumerate}
+\item \texttt{get\_submissions()} returns 50 wrapped submissions (no API calls)
+\item We filter to 1 submission (wrapper objects pass through filters)
+\item We access the grade attribute
+\item The wrapper detects access to mutable attribute, checks staleness
+\item We make 1 API call to refresh only the accessed submission
+\end{enumerate}
+
+The performance improvement is dramatic when filtering: \textbf{1 API call instead
+of 50}.
+
+\subsubsection{Design: LazySubmission wrapper}
+
+We implement lazy loading using a transparent wrapper class that intercepts
+attribute access.
+The wrapper stores the original submission and assignment reference, allowing it
+to refresh itself when needed.
+
+Key design decisions:
+\begin{description}
+\item[Mutable attributes] Only certain attributes change over time: grade,
+  grading dates, rubrics, submission data, comments, attachments, and submission
+  body.
+  We track these and trigger refresh only when they're accessed.
+\item[NOREFRESH\_GRADES behavior] Submissions with final grades (A, P, P+,
+  complete) are never refreshed, maintaining the existing policy.
+\item[Time-based staleness] We use the existing \texttt{outdated()} function
+  with 5-minute TTL for non-final grades.
+\item[Preserved includes] The wrapper stores the original \texttt{include}
+  parameters from \texttt{get\_submissions()} to ensure refreshes request the
+  same data.
+\item[Cache updates] When a wrapper refreshes, it updates its internal state.
+  Since the cache holds references to wrapper objects, the cache automatically
+  reflects the update.
+\end{description}
+
+\subsubsection{Implementation: LazySubmission class}
+
+The \texttt{LazySubmission} class wraps a submission object and intercepts
+attribute access using \texttt{\_\_getattribute\_\_}.
+
+<<LazySubmission class>>=
+class LazySubmission:
+  """
+  Transparent wrapper for Submission objects that lazily refreshes on access.
+
+  This wrapper intercepts access to mutable attributes (grade, timestamps,
+  rubrics, etc.) and refreshes the submission from Canvas if:
+  - The submission is stale (based on TTL)
+  - The grade is not a final grade (not in NOREFRESH_GRADES)
+
+  Immutable attributes (user_id, assignment_id, etc.) are accessed directly
+  without triggering a refresh.
+  """
+
+  # Attributes that can change and should trigger refresh when accessed
+  MUTABLE_ATTRS = {
+    'grade', 'graded_at', 'submitted_at', 'rubric_assessment',
+    'submission_data', 'submission_history', 'submission_comments',
+    'attachments', 'body', 'grade_matches_current_submission'
+  }
+
+  def __init__(self, submission, assignment, includes, original_get_submission):
+    """
+    Initialize lazy submission wrapper.
+
+    Parameters:
+      submission: The Submission object to wrap
+      assignment: The Assignment object this submission belongs to
+      includes: List of include parameters used when fetching
+      original_get_submission: Unwrapped get_submission method for refreshing
+    """
+    # Use object.__setattr__ to avoid triggering our custom __setattr__
+    object.__setattr__(self, '_submission', submission)
+    object.__setattr__(self, '_assignment', assignment)
+    object.__setattr__(self, '_includes', includes)
+    object.__setattr__(self, '_original_get_submission', original_get_submission)
+    object.__setattr__(self, '_last_refresh', datetime.now())
+
+  def _needs_refresh(self):
+    """Check if the wrapped submission needs refreshing."""
+    submission = object.__getattribute__(self, '_submission')
+    last_refresh = object.__getattribute__(self, '_last_refresh')
+
+    # Never refresh final grades
+    if submission.grade in NOREFRESH_GRADES:
+      return False
+
+    # Check time-based staleness (5-minute TTL for non-final grades)
+    if datetime.now() - last_refresh > timedelta(minutes=5):
+      return True
+
+    return False
+
+  def _refresh(self):
+    """Refresh the wrapped submission from Canvas."""
+    assignment = object.__getattribute__(self, '_assignment')
+    submission = object.__getattribute__(self, '_submission')
+    includes = object.__getattribute__(self, '_includes')
+    original_get_submission = object.__getattribute__(self, '_original_get_submission')
+
+    # Call original method directly (bypasses decorator, no double-wrapping)
+    fresh_submission = original_get_submission(
+      assignment,
+      submission.user_id,
+      include=list(includes)
+    )
+
+    # Update internal state (cache automatically updated via reference)
+    object.__setattr__(self, '_submission', fresh_submission)
+    object.__setattr__(self, '_last_refresh', datetime.now())
+
+  def __getattribute__(self, name):
+    """
+    Intercept attribute access to trigger refresh when needed.
+
+    Logic:
+    1. Internal attributes (_*) and methods: access directly
+    2. Mutable attributes: check staleness, refresh if needed, then delegate
+    3. All other attributes: delegate to wrapped submission
+    """
+    # Always access internal attributes directly to avoid recursion
+    if name.startswith('_') or name in ['MUTABLE_ATTRS']:
+      return object.__getattribute__(self, name)
+
+    # Check if this is a mutable attribute that might need refresh
+    if name in LazySubmission.MUTABLE_ATTRS:
+      if object.__getattribute__(self, '_needs_refresh')():
+        object.__getattribute__(self, '_refresh')()
+
+    # Delegate to wrapped submission
+    submission = object.__getattribute__(self, '_submission')
+    return getattr(submission, name)
+
+  def __setattr__(self, name, value):
+    """
+    Intercept attribute setting to handle both wrapper and submission attrs.
+
+    Internal attributes (_*) are set on the wrapper.
+    All other attributes are set on the wrapped submission.
+    """
+    if name.startswith('_'):
+      object.__setattr__(self, name, value)
+    else:
+      submission = object.__getattribute__(self, '_submission')
+      setattr(submission, name, value)
+
+  def __getattr__(self, name):
+    """Fallback for attributes not found on wrapper (delegates to submission)."""
+    submission = object.__getattribute__(self, '_submission')
+    return getattr(submission, name)
+
+  def __repr__(self):
+    """Delegate repr to wrapped submission."""
+    submission = object.__getattribute__(self, '_submission')
+    return repr(submission)
+
+  def __str__(self):
+    """Delegate str to wrapped submission."""
+    submission = object.__getattribute__(self, '_submission')
+    return str(submission)
+@
+
+This class is used by the caching decorator below.
+<<functions>>=
+<<LazySubmission class>>
+@
+
 \subsection{Caching submissions}
 
 For the results, we can construct something more specific.
 Results that we're interested in are submissions.
 We can only get submission from an assignment object.
-We can either get all submissions, or one specific submission if we specify the 
+We can either get all submissions, or one specific submission if we specify the
 user.
+
+Now we combine the caching mechanism with lazy loading.
+The cache stores \texttt{LazySubmission} wrappers instead of raw submissions.
+This means submissions are only refreshed when their attributes are actually
+accessed, not when the list is returned.
 <<functions>>=
 def make_assignment_submissions_cacheable():
   def cache_submissions(cls):

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1022,6 +1022,56 @@ class LazySubmission:
     """Delegate str to wrapped submission."""
     submission = object.__getattribute__(self, '_submission')
     return str(submission)
+
+  def __getstate__(self):
+    """
+    Prepare object for pickling.
+
+    We can't pickle method references, so we exclude _original_get_submission.
+    It will be restored from the assignment object during unpickling.
+    """
+    state = {
+      '_submission': object.__getattribute__(self, '_submission'),
+      '_assignment': object.__getattribute__(self, '_assignment'),
+      '_includes': object.__getattribute__(self, '_includes'),
+      '_last_refresh': object.__getattribute__(self, '_last_refresh'),
+    }
+    return state
+
+  def __setstate__(self, state):
+    """
+    Restore object after unpickling.
+
+    Restore all attributes from state, and reconstruct _original_get_submission
+    by finding it in the decorator's closure.
+    """
+    for key, value in state.items():
+      object.__setattr__(self, key, value)
+
+    # Restore the original method from the assignment's decorated method
+    # The decorated method has the original in its closure
+    assignment = state['_assignment']
+    decorated_method = assignment.__class__.get_submission
+
+    # The original method is captured in the decorator's closure
+    # We can access it via the closure of the decorated method
+    # The decorated method's __closure__ contains the original method
+    try:
+      # Find the original_get_submission in the closure
+      for cell in decorated_method.__closure__:
+        try:
+          obj = cell.cell_contents
+          # Check if it's a callable with the right name
+          if callable(obj) and hasattr(obj, '__name__') and \
+             'get_submission' in obj.__name__:
+            object.__setattr__(self, '_original_get_submission', obj)
+            break
+        except (AttributeError, ValueError):
+          continue
+    except (AttributeError, TypeError):
+      # If we can't find it in closure, fall back to None
+      # This means refresh won't work, but at least unpickling succeeds
+      object.__setattr__(self, '_original_get_submission', None)
 @
 
 This class is used by the caching decorator below.

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -20,7 +20,11 @@ from datetime import datetime, timedelta
 import functools
 import importlib
 import inspect
+import logging
+import os
 import sys
+
+logger = logging.getLogger(__name__)
 
 <<constants>>
 <<functions>>
@@ -671,6 +675,11 @@ So the only grades that we should use are passing grades that can't be
 improved.
 <<constants>>=
 NOREFRESH_GRADES = ["A", "P", "P+", "complete"]
+
+# Threshold for bulk refresh optimization
+# Can be overridden via environment variables
+BULK_REFRESH_THRESHOLD = float(os.environ.get('CANVASLMS_BULK_THRESHOLD', '0.2'))
+BULK_REFRESH_MIN_COUNT = int(os.environ.get('CANVASLMS_BULK_MIN_COUNT', '3'))
 @
 
 Another thing that we can do is to periodically reset the [[_all_fetched]] 
@@ -954,6 +963,18 @@ class LazySubmission:
       return True
 
     return False
+
+  def would_need_refresh(self):
+    """
+    Check if submission would need refresh WITHOUT triggering it.
+
+    Used by pre-check phase to count stale submissions before deciding
+    whether to do bulk refresh.
+
+    Returns:
+        bool: True if submission would refresh on next access
+    """
+    return self._needs_refresh()
 
   def _refresh(self):
     """Refresh the wrapped submission from Canvas."""
@@ -1333,6 +1354,9 @@ if "include" in kwargs:
 else:
   to_include = set()
 
+# Extract check_bulk_refresh parameter (default: False)
+check_bulk_refresh = kwargs.get("check_bulk_refresh", False)
+
 # Check if we need to refetch due to new includes
 need_refetch = False
 if self.__all_fetched:
@@ -1357,8 +1381,58 @@ if not self.__all_fetched or need_refetch:
     self.__cache[raw_submission.user_id] = lazy_submission
 
   self.__all_fetched = datetime.now()
+elif check_bulk_refresh:
+  # Cache exists, includes satisfied, AND caller requested bulk refresh check
+  <<check staleness threshold and bulk refresh if needed>>
 
 # Return list of LazySubmission wrappers (no staleness checks here!)
 return list(self.__cache.values())
+@
+
+The bulk refresh pre-check logic counts how many submissions would need refresh
+and triggers a bulk fetch if the count exceeds the threshold.
+<<check staleness threshold and bulk refresh if needed>>=
+stale_count = 0
+total_count = len(self.__cache)
+
+if total_count > 0:
+  # Count stale submissions (non-mutating check)
+  for lazy_submission in self.__cache.values():
+    if lazy_submission.would_need_refresh():
+      stale_count += 1
+
+  # Calculate threshold
+  if isinstance(BULK_REFRESH_THRESHOLD, float):
+    threshold = max(int(total_count * BULK_REFRESH_THRESHOLD),
+                   BULK_REFRESH_MIN_COUNT)
+  else:
+    threshold = BULK_REFRESH_THRESHOLD
+
+  # If threshold exceeded, perform bulk refresh
+  if stale_count >= threshold:
+    logger.info(f"Bulk refresh: {stale_count}/{total_count} submissions stale, "
+                f"threshold={threshold}")
+
+    # Merge all includes from cached submissions
+    all_includes = set()
+    for lazy_submission in self.__cache.values():
+      all_includes |= set(lazy_submission._includes)
+    all_includes |= to_include
+
+    # Perform bulk refresh (1 API call)
+    for raw_submission in get_submissions(self, include=list(all_includes)):
+      if raw_submission.user_id in self.__cache:
+        # Update existing wrapper in-place
+        lazy_submission = self.__cache[raw_submission.user_id]
+        object.__setattr__(lazy_submission, '_submission', raw_submission)
+        object.__setattr__(lazy_submission, '_last_refresh', datetime.now())
+        object.__setattr__(lazy_submission, '_includes', all_includes)
+      else:
+        # New submission appeared since cache was created
+        lazy_submission = LazySubmission(raw_submission, self, all_includes,
+                                       original_get_submission)
+        self.__cache[raw_submission.user_id] = lazy_submission
+
+    self.__all_fetched = datetime.now()
 @
 

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -836,7 +836,7 @@ def make_course_groups_cacheable():
 \subsection{Lazy-loading submissions}
 
 The current caching approach has an inefficiency: when we call
-\texttt{get\_submissions()}, we immediately check if each cached submission needs
+[[get_submissions()]], we immediately check if each cached submission needs
 updating and refresh it if necessary.
 However, in many workflows we filter the submission list to access only a few
 submissions (e.g., filtering by user or assignment).
@@ -853,7 +853,7 @@ print(filtered[0].grade)
 
 With \emph{eager loading} (the old approach):
 \begin{enumerate}
-\item \texttt{get\_submissions()} returns 50 cached submissions
+\item [[get_submissions()]] returns 50 cached submissions
 \item We check each submission: is it stale? Does it need refresh?
 \item We make 50 API calls to refresh non-final grades
 \item We filter to 1 submission
@@ -862,7 +862,7 @@ With \emph{eager loading} (the old approach):
 
 With \emph{lazy loading} (the new approach):
 \begin{enumerate}
-\item \texttt{get\_submissions()} returns 50 wrapped submissions (no API calls)
+\item [[get_submissions()]] returns 50 wrapped submissions (no API calls)
 \item We filter to 1 submission (wrapper objects pass through filters)
 \item We access the grade attribute
 \item The wrapper detects access to mutable attribute, checks staleness
@@ -885,12 +885,12 @@ Key design decisions:
   grading dates, rubrics, submission data, comments, attachments, and submission
   body.
   We track these and trigger refresh only when they're accessed.
-\item[NOREFRESH\_GRADES behavior] Submissions with final grades (A, P, P+,
-  complete) are never refreshed, maintaining the existing policy.
-\item[Time-based staleness] We use the existing \texttt{outdated()} function
+\item[Final grade policy] Submissions with final grades (A, P, P+, complete)
+  are never refreshed, maintaining the existing [[NOREFRESH_GRADES]] policy.
+\item[Time-based staleness] We use the existing [[outdated()]] function
   with 5-minute TTL for non-final grades.
-\item[Preserved includes] The wrapper stores the original \texttt{include}
-  parameters from \texttt{get\_submissions()} to ensure refreshes request the
+\item[Preserved includes] The wrapper stores the original [[include]]
+  parameters from [[get_submissions()]] to ensure refreshes request the
   same data.
 \item[Cache updates] When a wrapper refreshes, it updates its internal state.
   Since the cache holds references to wrapper objects, the cache automatically
@@ -899,8 +899,8 @@ Key design decisions:
 
 \subsubsection{Implementation: LazySubmission class}
 
-The \texttt{LazySubmission} class wraps a submission object and intercepts
-attribute access using \texttt{\_\_getattribute\_\_}.
+The [[LazySubmission]] class wraps a submission object and intercepts
+attribute access using [[__getattribute__]].
 
 <<LazySubmission class>>=
 class LazySubmission:
@@ -1028,15 +1028,15 @@ class LazySubmission:
 
 \subsubsection{Pickle support for cache persistence}
 
-The \texttt{LazySubmission} wrapper must support pickling to enable cache
+The [[LazySubmission]] wrapper must support pickling to enable cache
 persistence.
-When the \texttt{Canvas} object is saved to disk (see cache.nw), Python's
-\texttt{pickle} module serializes the entire object hierarchy, including all
+When the [[Canvas]] object is saved to disk (see cache.nw), Python's
+[[pickle]] module serializes the entire object hierarchy, including all
 cached submissions.
 
 \paragraph{The pickling challenge}
 
-Python's \texttt{pickle} cannot serialize certain objects, including:
+Python's [[pickle]] cannot serialize certain objects, including:
 \begin{itemize}
 \item Function and method references (unless they're module-level functions)
 \item Lambda functions
@@ -1044,38 +1044,38 @@ Python's \texttt{pickle} cannot serialize certain objects, including:
 \item Objects with circular references to unpicklable objects
 \end{itemize}
 
-Our \texttt{LazySubmission} stores \texttt{\_original\_get\_submission}, which is
-a reference to the original (unwrapped) \texttt{get\_submission} method.
+Our [[LazySubmission]] stores [[_original_get_submission]], which is
+a reference to the original (unwrapped) [[get_submission]] method.
 This is a \emph{bound method} when called, but we store the \emph{unbound
 function} from the decorator's closure.
 Method objects are not picklable by default.
 
 \paragraph{The solution: reconstruct from closure}
 
-We implement \texttt{\_\_getstate\_\_} and \texttt{\_\_setstate\_\_} to handle
+We implement [[__getstate__]] and [[__setstate__]] to handle
 pickling:
 \begin{enumerate}
-\item \textbf{Before pickling} (\texttt{\_\_getstate\_\_}): Exclude the
-  unpicklable \texttt{\_original\_get\_submission} from the state dictionary.
+\item \textbf{Before pickling} ([[__getstate__]]): Exclude the
+  unpicklable [[_original_get_submission]] from the state dictionary.
   Save only the submission, assignment reference, includes list, and last
   refresh timestamp.
-\item \textbf{After unpickling} (\texttt{\_\_setstate\_\_}): Reconstruct
-  \texttt{\_original\_get\_submission} by searching the decorator's closure.
-  The decorated method stores the original in its \texttt{\_\_closure\_\_}
+\item \textbf{After unpickling} ([[__setstate__]]): Reconstruct
+  [[_original_get_submission]] by searching the decorator's closure.
+  The decorated method stores the original in its [[__closure__]]
   attribute, which we can access via
-  \texttt{assignment.\_\_class\_\_.get\_submission}.
+  [[assignment.__class__.get_submission]].
 \end{enumerate}
 
 \paragraph{Why closure search works}
 
-When the \texttt{cache\_submissions} decorator wraps
-\texttt{Assignment.get\_submission}, it captures the original method in a
+When the [[cache_submissions]] decorator wraps
+[[Assignment.get_submission]], it captures the original method in a
 closure variable (line~1072 in the decorator):
 \begin{minted}{python}
 original_get_submission = cls.get_submission
 \end{minted}
 
-This variable is referenced by the \texttt{new\_get\_submission} function,
+This variable is referenced by the [[new_get_submission]] function,
 making it part of the function's closure.
 After unpickling, we can access this closure via the class's decorated method.
 
@@ -1090,9 +1090,9 @@ This approach has several limitations:
   \enquote{get\_submission} in their name, we might retrieve the wrong one.
   The heuristic checks for callables with matching names.
 \item[Graceful degradation] If reconstruction fails, we set
-  \texttt{\_original\_get\_submission} to \texttt{None}.
+  [[_original_get_submission]] to [[None]].
   The wrapper remains functional for read-only access (attributes pass through
-  to the wrapped submission), but calling \texttt{\_refresh()} will fail.
+  to the wrapped submission), but calling [[_refresh()]] will fail.
   This is acceptable because:
   \begin{itemize}
   \item Cache files are typically invalidated on code changes
@@ -1105,8 +1105,8 @@ This approach has several limitations:
 
 We considered but rejected these alternatives:
 \begin{description}
-\item[Storing method name as string] Reconstruct via \texttt{getattr(assignment,
-  'get\_submission')}.
+\item[Storing method name as string] Reconstruct via
+  [[getattr(assignment, 'get_submission')]].
   Problem: This retrieves the \emph{decorated} method, not the original,
   causing infinite recursion or double-wrapping.
 \item[Not using a wrapper] Store a \enquote{needs refresh} flag on the

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1053,9 +1053,11 @@ def make_assignment_submissions_cacheable():
 @
 
 Then we can write the decorator as follows.
-We need to add a cache attribute in the constructor, so we must decorate the 
+We need to add a cache attribute in the constructor, so we must decorate the
 constructor.
-The we must decorate both [[get_submission]] and [[get_submissions]].
+We must also store the original [[get_submission]] method before decorating it,
+because [[LazySubmission]] needs to call it directly to avoid double-wrapping.
+Then we must decorate both [[get_submission]] and [[get_submissions]].
 <<decorator body for caching assignment submissions>>=
 old_constructor = cls.__init__
 
@@ -1066,6 +1068,8 @@ def new_init(*args, **kwargs):
 
 cls.__init__ = new_init
 
+# Store original method before wrapping (needed by LazySubmission)
+original_get_submission = cls.get_submission
 get_submission = cls.get_submission
 
 @functools.wraps(cls.get_submission)
@@ -1084,15 +1088,20 @@ cls.get_submissions = new_get_submissions
 @
 
 We decorate the method to get a specific submission, [[get_submission]].
-This way we can cache the submissions of users who have passed.
-Then we always return up-to-date submissions of students who are expected to 
-submit.
+With lazy loading, we wrap the submission in [[LazySubmission]] and cache the
+wrapper.
+The wrapper will handle staleness checking and refresh only when attributes are
+accessed.
 For this, we first need a cache attribute.
 <<extend class constructor for decorators>>=
 args[0].__cache = {}
 @
 
 Now we can treat how we get an individual submission.
+The logic is simplified compared to the eager approach: we only fetch if not in
+cache or if new includes are requested.
+We no longer check [[NOREFRESH_GRADES]] here---that's handled by
+[[LazySubmission._needs_refresh()]].
 <<return submission of user>>=
 if isinstance(user, User):
   uid = user.id
@@ -1101,52 +1110,81 @@ elif isinstance(user, int):
 else:
   raise TypeError(f"user must be User or int")
 
-submission = None
-
 if "include" in kwargs:
   to_include = set(kwargs["include"])
 else:
   to_include = set()
 
+# Check cache
 if uid in self.__cache:
-  submission, included = self.__cache[uid]
-  if not to_include.issubset(set(included)):
-    submission = None
-    to_include |= set(included)
+  lazy_submission = self.__cache[uid]
+  # Get current includes from the wrapper
+  current_includes = set(lazy_submission._includes)
 
-if not submission or submission.grade not in NOREFRESH_GRADES:
-  submission = get_submission(self, user, include=list(to_include))
-  self.__cache[uid] = (submission, to_include)
+  # If new includes are requested, merge and refetch
+  if not to_include.issubset(current_includes):
+    to_include |= current_includes
+    raw_submission = get_submission(self, user, include=list(to_include))
+    lazy_submission = LazySubmission(raw_submission, self, to_include,
+                                     original_get_submission)
+    self.__cache[uid] = lazy_submission
 
-return submission
+  return lazy_submission
+else:
+  # Not in cache, fetch and wrap
+  raw_submission = get_submission(self, user, include=list(to_include))
+  lazy_submission = LazySubmission(raw_submission, self, to_include,
+                                   original_get_submission)
+  self.__cache[uid] = lazy_submission
+  return lazy_submission
 @
 
 Now we can deal with [[get_submissions]].
-As we might call [[get_submission]] before any [[get_submissions]], we cannot 
+As we might call [[get_submission]] before any [[get_submissions]], we cannot
 rely on the cache as a check.
 We introduce a new attribute.
 <<extend class constructor for decorators>>=
 args[0].__all_fetched = False
 @ Now we can check if this is set or not.
 When we fetch, we want to include any data that was previously included.
+
+With lazy loading, we simplify the logic significantly.
+We no longer check each submission for staleness here---the [[LazySubmission]]
+wrapper handles that when attributes are accessed.
+We only refetch all if we haven't fetched before, or if new includes are
+requested that aren't in the cache.
 <<return a list of all submissions>>=
 if "include" in kwargs:
   to_include = set(kwargs["include"])
 else:
   to_include = set()
 
+# Check if we need to refetch due to new includes
+need_refetch = False
 if self.__all_fetched:
-  for submission, included in self.__cache.values():
-    if not to_include.issubset(included) or \
-       submission.grade not in NOREFRESH_GRADES:
-      self.get_submission(submission.user_id, include=list(to_include))
-else:
-  for _, included in self.__cache.values():
-    to_include |= included
+  # Check if any cached submission doesn't have the requested includes
+  for lazy_submission in self.__cache.values():
+    cached_includes = set(lazy_submission._includes)
+    if not to_include.issubset(cached_includes):
+      need_refetch = True
+      to_include |= cached_includes
+      break
 
-  for submission in get_submissions(self, **kwargs):
-    self.__cache[submission.user_id] = (submission, to_include)
+if not self.__all_fetched or need_refetch:
+  # If refetching, merge all previously requested includes
+  if need_refetch:
+    for lazy_submission in self.__cache.values():
+      to_include |= set(lazy_submission._includes)
 
-return [submission for submission, _ in self.__cache.values()]
+  # Fetch all and wrap with LazySubmission
+  for raw_submission in get_submissions(self, include=list(to_include)):
+    lazy_submission = LazySubmission(raw_submission, self, to_include,
+                                     original_get_submission)
+    self.__cache[raw_submission.user_id] = lazy_submission
+
+  self.__all_fetched = True
+
+# Return list of LazySubmission wrappers (no staleness checks here!)
+return list(self.__cache.values())
 @
 

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1198,6 +1198,120 @@ This class is used by the caching decorator below.
 <<LazySubmission class>>
 @
 
+\subsubsection{Threshold-based bulk refresh optimization}
+
+While lazy loading solves the problem of wasted refreshes when filtering
+submissions, it introduces a new inefficiency in the opposite scenario: when
+workflows access \emph{all} submissions' mutable attributes, lazy loading
+triggers individual API calls for each stale submission.
+
+\paragraph{The performance bottleneck}
+
+Consider the [[-U]] (ungraded) option in [[submissions.nw]]:
+\begin{minted}{python}
+for submission in submissions:
+    if is_submission_ungraded(submission):
+        yield submission
+\end{minted}
+
+The [[is_submission_ungraded()]] function checks [[submitted_at]],
+[[graded_at]], and [[grade_matches_current_submission]]---all mutable
+attributes.
+With 50 submissions where 40 are stale:
+\begin{enumerate}
+\item Access [[submission.submitted_at]] → triggers refresh check
+\item Submission is stale → makes API call to refresh
+\item Repeat for all 50 submissions
+\item Result: 40 individual API calls
+\end{enumerate}
+
+This is \textbf{40× slower} than fetching all submissions in one bulk request.
+
+\paragraph{The solution: pre-check and bulk refresh}
+
+We add an optional pre-check phase that counts how many submissions would need
+refresh before accessing them. If the count exceeds a threshold, we trigger one
+bulk fetch instead of many individual refreshes.
+
+The optimization is opt-in via a [[check_bulk_refresh]] parameter to
+[[get_submissions()]]:
+\begin{enumerate}
+\item Count stale submissions using [[would_need_refresh()]] (non-mutating check)
+\item Calculate threshold: [[max(total × 0.2, 3)]] (20\% with minimum 3)
+\item If [[stale_count ≥ threshold]], perform bulk refresh (1 API call)
+\item Update all [[LazySubmission]] wrappers in-place with fresh data
+\item Return refreshed cache so subsequent attribute access doesn't trigger refreshes
+\end{enumerate}
+
+\paragraph{When to enable bulk refresh}
+
+The optimization is beneficial when workflows will access mutable attributes on
+\emph{most} submissions:
+\begin{description}
+\item[[{-U}]] (ungraded option)] Always enabled---checks all submissions'
+  grading state
+\item[Unfiltered listings] Enabled when no [[--user]], [[--category]], or
+  [[--group]] filters are applied
+\item[Specific user filtering] Disabled---only a few submissions will be
+  accessed
+\end{description}
+
+\paragraph{Threshold configuration}
+
+The threshold is configurable via environment variables:
+\begin{description}
+\item[[CANVASLMS_BULK_THRESHOLD]] Fraction of stale submissions needed (default:
+  0.2 = 20\%)
+\item[[CANVASLMS_BULK_MIN_COUNT]] Minimum number of stale submissions required
+  (default: 3)
+\end{description}
+
+Examples:
+\begin{itemize}
+\item Small assignment (10 submissions): threshold = [[max(2, 3) = 3]] (30\%)
+\item Medium assignment (50 submissions): threshold = 10 (20\%)
+\item Large assignment (200 submissions): threshold = 40 (20\%)
+\end{itemize}
+
+\paragraph{Trade-offs}
+
+\emph{Advantages:}
+\begin{itemize}
+\item Dramatic reduction in API calls for [[-U]] scenarios (40 calls → 1 call)
+\item Faster execution when many submissions are accessed
+\item Respects final grade policy ([[NOREFRESH_GRADES]] never counted as stale)
+\item Updates cache in-place (preserves object identity and references)
+\end{itemize}
+
+\emph{Disadvantages:}
+\begin{itemize}
+\item Pre-check adds overhead (one pass through cache to count staleness)
+\item May refresh submissions that won't ultimately be accessed (if filtering
+  happens after refresh)
+\item Bulk refresh fetches all includes, increasing response size slightly
+\end{itemize}
+
+The threshold (20\% minimum 3) balances these trade-offs: we only bulk refresh
+when it's likely to save significant API calls.
+
+\paragraph{Design rationale}
+
+Why implement in the decorator, not in [[LazySubmission]]?
+\begin{itemize}
+\item The decorator has access to the entire cache (all submissions)
+\item [[LazySubmission]] only knows about individual submissions
+\item Threshold calculation requires global view of staleness
+\item Bulk refresh requires coordinating multiple wrappers
+\end{itemize}
+
+Why opt-in instead of automatic?
+\begin{itemize}
+\item Filtering workflows benefit from lazy loading (don't want bulk refresh)
+\item [[-U]] and unfiltered listings benefit from bulk refresh
+\item Call site knows the access pattern, decorator doesn't
+\item Opt-in ensures we only bulk refresh when beneficial
+\end{itemize}
+
 \subsection{Caching submissions}
 
 For the results, we can construct something more specific.

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1290,9 +1290,12 @@ else:
 Now we can deal with [[get_submissions]].
 As we might call [[get_submission]] before any [[get_submissions]], we cannot
 rely on the cache as a check.
-We introduce a new attribute.
+We introduce a new attribute, initialized to [[None]] to indicate that no bulk
+fetch has been performed yet.
+This follows the same pattern as [[CacheGetMethods]], which uses [[None]] for
+\enquote{not fetched} and [[datetime.now()]] for \enquote{last fetch time}.
 <<extend class constructor for decorators>>=
-args[0].__all_fetched = False
+args[0].__all_fetched = None
 @ Now we can check if this is set or not.
 When we fetch, we want to include any data that was previously included.
 
@@ -1330,7 +1333,7 @@ if not self.__all_fetched or need_refetch:
                                      original_get_submission)
     self.__cache[raw_submission.user_id] = lazy_submission
 
-  self.__all_fetched = True
+  self.__all_fetched = datetime.now()
 
 # Return list of LazySubmission wrappers (no staleness checks here!)
 return list(self.__cache.values())


### PR DESCRIPTION
- **Add LazySubmission wrapper class for lazy-loading submissions**
- **Integrate LazySubmission into cache_submissions decorator**
- **Add pickle support for LazySubmission**
- **Document pickle support limitations and design decisions**
- **Add content-addressed attachment caching module**
- **Integrate attachment cache into submission downloads**
- **Add clear-attachments subcommand**
- **Add description to cache clear command**
