### PR TITLE
Enhance cache diagnostic logging

### DIFF
--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -494,8 +494,9 @@ if obj and must_update(prev_kwargs, kwargs):
   obj = None
   cache_status = " (new kwargs required)"
 elif obj and outdated(obj):
+  reason = get_staleness_reason(obj)
   obj = None
-  cache_status = " (stale)"
+  cache_status = f" (stale: {reason})" if reason else " (stale)"
 
 if not obj:
   fetch_start = time.perf_counter()
@@ -577,14 +578,56 @@ attr_all_fetched = getattr(self, f"{attr_name}_all_fetched")
 if attr_all_fetched:
   for _, prev_kwargs in attr_cache.values():
     if must_update(prev_kwargs, kwargs):
+      logger.info(f"Cache invalidation: {attr_name}s - new kwargs required "
+                  f"(existing: {prev_kwargs}, requested: {kwargs})")
       attr_all_fetched = None
       break
 
 if not attr_all_fetched:
+  <<log reason for bulk refresh>>
   <<fetch all and populate [[attr_cache]]>>
   <<yield all objects in [[attr_cache]]>>
 else:
+  cache_age = datetime.now() - attr_all_fetched
+  stale_count = sum(1 for obj, _ in attr_cache.values() if outdated(obj))
+  logger.info(f"Using cached {attr_name}s: {len(attr_cache)} cached "
+              f"(age: {cache_age.total_seconds()/60:.1f} minutes, "
+              f"{stale_count} stale), updating stale entries individually")
   <<yield all objects in [[attr_cache]], update individual entries if needed>>
+@
+
+\subsection{Logging cache decisions}
+
+To make cache behavior transparent, we log key decision points in the plural
+[[get_xs]] methods. This follows the same diagnostic pattern as submission-specific
+caching (lines 1163-1183) but applies to the general [[CacheGetMethods]] decorator
+used by courses, users, assignments, and other Canvas objects.
+
+We log three critical decision points:
+\begin{enumerate}
+\item \textbf{Bulk fetch trigger}: When [[attr_all_fetched]] is [[None]], we log
+  whether this is the first fetch (cold cache) or a cache invalidation (TTL expired
+  or kwargs changed). This explains why a bulk refresh is happening.
+\item \textbf{Cached path usage}: When [[attr_all_fetched]] is set, we log the
+  cache age, total size, and how many entries are stale (requiring individual refresh).
+  This provides visibility into cache health and effectiveness.
+\item \textbf{Kwargs invalidation}: When [[must_update()]] detects that cached
+  objects don't have the requested kwargs (e.g., new [[include]] fields), we log
+  what changed before invalidating the cache. This explains why a bulk refresh
+  will occur even though the cache was populated.
+\end{enumerate}
+
+These logs, combined with the bulk refresh completion message (line 650-652)
+and kwargs merging log (lines 609-622), provide complete transparency into why
+courses, users, and assignments trigger bulk refreshes versus using cached data.
+
+When [[attr_all_fetched]] is [[None]], we determine and log the reason:
+<<log reason for bulk refresh>>=
+if not attr_cache:
+  refresh_reason = "first fetch (cold cache)"
+else:
+  refresh_reason = "cache invalidated"
+logger.info(f"Bulk fetch: {attr_name}s - {refresh_reason}")
 @
 
 To fetch all again, we must merge the keyword arguments.
@@ -600,8 +643,16 @@ overhead.
 import time
 bulk_start = time.perf_counter()
 
+original_includes = set(kwargs.get('include', []))
 union_kwargs = merge_kwargs(
   [kwargs for _, kwargs in attr_cache.values()] + [kwargs])
+merged_includes = set(union_kwargs.get('include', []))
+
+if merged_includes != original_includes:
+  added = merged_includes - original_includes
+  logger.info(f"Merging kwargs for {attr_name}: extending include fields "
+              f"from {sorted(original_includes)} to {sorted(merged_includes)} "
+              f"(added: {sorted(added)})")
 
 api_start = time.perf_counter()
 fetched_objs = list(get_attrs(self, *args, **union_kwargs))
@@ -619,7 +670,7 @@ setattr(self, f"{attr_name}_all_fetched", datetime.now())
 attr_all_fetched = getattr(self, f"{attr_name}_all_fetched")
 
 bulk_elapsed = time.perf_counter() - bulk_start
-logger.info(f"Bulk refresh: {len(fetched_objs)} {attr_name}s in "
+logger.info(f"Bulk refresh completed: {len(fetched_objs)} {attr_name}s fetched in "
             f"{bulk_elapsed:.2f}s (API: {api_elapsed:.2f}s, "
             f"processing: {process_elapsed:.2f}s)")
 @
@@ -641,11 +692,13 @@ beneficial.
 <<yield all objects in [[attr_cache]], update individual entries if needed>>=
 for obj, obj_kwargs in attr_cache.values():
   if outdated(obj):
+    reason = get_staleness_reason(obj)
+    reason_str = f" (reason: {reason})" if reason else ""
     refresh_start = time.perf_counter()
     obj = get_attr(self, obj.id, **obj_kwargs)
     refresh_elapsed = time.perf_counter() - refresh_start
     logger.info(f"Individual refresh: {attr_name} id={obj.id} in "
-                f"{refresh_elapsed:.2f}s")
+                f"{refresh_elapsed:.2f}s{reason_str}")
   yield obj
 <<yield all objects in [[attr_cache]]>>=
 for obj, _ in attr_cache.values():
@@ -709,13 +762,13 @@ except AttributeError:
   pass
 @
 
-For submissions without passing grades, we check if the 5-minute TTL has
-expired.
+For submissions without passing grades, we check if the [[SUBMISSION_TTL_MINUTES]]
+TTL has expired.
 If the object has no [[_fetched_at]] attribute, we treat it as outdated to
 ensure it gets refreshed.
 <<check if submission TTL has expired>>=
 try:
-  if datetime.now() - obj._fetched_at > timedelta(minutes=5):
+  if datetime.now() - obj._fetched_at > timedelta(minutes=SUBMISSION_TTL_MINUTES):
     return True
 except AttributeError:
   return True
@@ -725,10 +778,22 @@ Instinctively, we might want to use all passing grades as the grades that don't
 need refreshing.
 However, even if a student has gotten a B, they might want to improve their 
 grade.
-So the only grades that we should use are passing grades that can't be 
+So the only grades that we should use are passing grades that can't be
 improved.
 <<constants>>=
 NOREFRESH_GRADES = ["A", "P", "P+", "complete"]
+@
+
+We define constants for all cache time-to-live (TTL) values to ensure
+consistency between the [[outdated()]] function and log messages.
+When these values are tuned for performance, both the cache behavior and
+diagnostic messages update automatically.
+<<constants>>=
+# Cache TTL constants
+SUBMISSION_TTL_MINUTES = 5
+DEFAULT_CACHE_TTL_DAYS = 7
+USER_CACHE_TTL_DAYS = 2
+GROUP_CACHE_TTL_DAYS = 5
 @
 
 Another thing that we can do is to periodically reset the [[_all_fetched]] 
@@ -744,16 +809,25 @@ for attr_name in dir(obj):
   <<reset [[_all_fetched]] if necessary>>
 @
 
-We want to periodically reset the [[_all_fetched]] date so that we periodically 
+We want to periodically reset the [[_all_fetched]] date so that we periodically
 try to refetch all data.
 This interval will be different for different attributes.
-But we add a default of 7 days.
+But we add a default of [[DEFAULT_CACHE_TTL_DAYS]] days.
+
+When periodic refresh timers expire, we reset the [[_all_fetched]] flag to
+[[None]], triggering a bulk refresh on the next access. We log these
+invalidations at INFO level to explain why subsequent bulk refreshes occur.
+The log message includes both the cache age and the threshold, making it clear
+why the invalidation was triggered.
 <<reset [[_all_fetched]] if necessary>>=
 <<if statements for resetting [[_all_fetched]] for various attributes>>
 elif attr_name.endswith("_all_fetched"):
   if not getattr(obj, attr_name):
     continue
-  elif datetime.now() - getattr(obj, attr_name) > timedelta(days=7):
+  elif datetime.now() - getattr(obj, attr_name) > timedelta(days=DEFAULT_CACHE_TTL_DAYS):
+    age = datetime.now() - getattr(obj, attr_name)
+    logger.info(f"Cache invalidation: {attr_name} periodic refresh "
+                f"(age: {age.days} days, threshold: {DEFAULT_CACHE_TTL_DAYS} days)")
     setattr(obj, attr_name, None)
 @
 
@@ -766,12 +840,15 @@ So it will be useful to refetch them quite often.
 For instance, they're added at the beginning of the course, might fail to
 register and get removed, then readded when they're registered.
 Also, when a student reregister for the course, that might happen at any time.
-So a rather short interval is useful.
+So a rather short interval of [[USER_CACHE_TTL_DAYS]] days is useful.
 <<if statements for resetting [[_all_fetched]] for various attributes>>=
 if attr_name == "user_all_fetched":
   if not getattr(obj, attr_name):
     continue
-  elif datetime.now() - getattr(obj, attr_name) > timedelta(days=2):
+  elif datetime.now() - getattr(obj, attr_name) > timedelta(days=USER_CACHE_TTL_DAYS):
+    age = datetime.now() - getattr(obj, attr_name)
+    logger.info(f"Cache invalidation: user_all_fetched periodic refresh "
+                f"(age: {age.days} days, threshold: {USER_CACHE_TTL_DAYS} days)")
     setattr(obj, attr_name, None)
 @
 
@@ -779,13 +856,17 @@ Groups and group categories are more dynamic than assignment structure but less
 dynamic than user enrollments.
 Students are organized into groups for collaborative work, and group membership
 can change during the course (though less frequently than enrollment changes).
-We use 5 days as a compromise between freshness and API efficiency.
+We use [[GROUP_CACHE_TTL_DAYS]] days as a compromise between freshness and API
+efficiency.
 The prime number 5 ensures cache refreshes don't align with other attributes.
 <<if statements for resetting [[_all_fetched]] for various attributes>>=
 elif attr_name in ["group_all_fetched", "group_category_all_fetched"]:
   if not getattr(obj, attr_name):
     continue
-  elif datetime.now() - getattr(obj, attr_name) > timedelta(days=5):
+  elif datetime.now() - getattr(obj, attr_name) > timedelta(days=GROUP_CACHE_TTL_DAYS):
+    age = datetime.now() - getattr(obj, attr_name)
+    logger.info(f"Cache invalidation: {attr_name} periodic refresh "
+                f"(age: {age.days} days, threshold: {GROUP_CACHE_TTL_DAYS} days)")
     setattr(obj, attr_name, None)
 @
 
@@ -793,6 +874,99 @@ The [[outdated]] function is used by the caching decorator to check if cached
 objects need refreshing.
 <<functions>>=
 <<function [[outdated]] to test if an object is outdated>>
+@
+
+
+\subsection{Diagnosing cache staleness}
+
+To make cache behavior transparent and debuggable, we need to log not just
+\emph{that} objects are stale, but \emph{why} they're stale. The [[outdated()]]
+function implements three distinct staleness policies:
+\begin{enumerate}
+\item \textbf{Grade-based staleness}: Submissions without passing grades
+  (A, P, P+, complete) are cached for only [[SUBMISSION_TTL_MINUTES]] minutes,
+  allowing students to see updated grades quickly.
+\item \textbf{Periodic refresh}: Each cached collection ([[_all_fetched]]
+  timestamps) has a time-to-live ([[DEFAULT_CACHE_TTL_DAYS]] days default,
+  [[USER_CACHE_TTL_DAYS]] days for users, [[GROUP_CACHE_TTL_DAYS]] days
+  for groups) after which the entire collection is refetched.
+\item \textbf{Missing metadata}: Objects without [[_fetched_at]] attributes
+  are treated as stale to ensure they get refreshed.
+\end{enumerate}
+
+When we log cache operations, we want to distinguish between these cases.
+The [[get_staleness_reason()]] function mirrors [[outdated()]]'s logic but
+returns human-readable diagnostic strings instead of booleans.
+Both functions reference the same TTL constants, ensuring that log messages
+accurately describe the cache behavior.
+
+<<function [[get_staleness_reason]] to diagnose staleness>>=
+def get_staleness_reason(obj):
+  """
+  Returns a descriptive string explaining why obj is stale, or None if fresh.
+  Mirrors the logic in outdated() but returns human-readable reasons.
+  Uses constants for TTL values to ensure consistency with outdated() logic.
+  """
+  <<check submission grade-based staleness and return reason>>
+  <<check periodic refresh staleness and return reason>>
+  return None
+@
+
+We log the specific reason for staleness to help diagnose cache behavior.
+This distinguishes between the three staleness policies and shows how long
+objects have been stale, making it clear why refreshes are occurring.
+
+For grade-based staleness, we check if the submission has a non-passing grade
+and if the TTL has expired:
+<<check submission grade-based staleness and return reason>>=
+try:
+  if obj.grade not in NOREFRESH_GRADES:
+    try:
+      age = datetime.now() - obj._fetched_at
+      ttl = timedelta(minutes=SUBMISSION_TTL_MINUTES)
+      if age > ttl:
+        expired_by = age - ttl
+        return (f"non-passing grade ({obj.grade}), "
+                f"{SUBMISSION_TTL_MINUTES}-minute TTL expired "
+                f"{expired_by.total_seconds()/60:.1f} minutes ago")
+    except AttributeError:
+      return "non-passing grade, missing _fetched_at attribute"
+except AttributeError:
+  pass
+@
+
+For periodic refresh, we check the [[_all_fetched]] timestamps and report
+which specific attribute triggered the refresh:
+<<check periodic refresh staleness and return reason>>=
+for attr_name in dir(obj):
+  if attr_name == "user_all_fetched":
+    attr_val = getattr(obj, attr_name, None)
+    if attr_val:
+      age = datetime.now() - attr_val
+      threshold = timedelta(days=USER_CACHE_TTL_DAYS)
+      if age > threshold:
+        return (f"periodic refresh: {attr_name} "
+                f"(age: {age.days} days, threshold: {USER_CACHE_TTL_DAYS} days)")
+  elif attr_name in ["group_all_fetched", "group_category_all_fetched"]:
+    attr_val = getattr(obj, attr_name, None)
+    if attr_val:
+      age = datetime.now() - attr_val
+      threshold = timedelta(days=GROUP_CACHE_TTL_DAYS)
+      if age > threshold:
+        return (f"periodic refresh: {attr_name} "
+                f"(age: {age.days} days, threshold: {GROUP_CACHE_TTL_DAYS} days)")
+  elif attr_name.endswith("_all_fetched"):
+    attr_val = getattr(obj, attr_name, None)
+    if attr_val:
+      age = datetime.now() - attr_val
+      threshold = timedelta(days=DEFAULT_CACHE_TTL_DAYS)
+      if age > threshold:
+        return (f"periodic refresh: {attr_name} "
+                f"(age: {age.days} days, threshold: {DEFAULT_CACHE_TTL_DAYS} days)")
+@
+
+<<functions>>=
+<<function [[get_staleness_reason]] to diagnose staleness>>
 @
 
 
@@ -1002,7 +1176,8 @@ def must_refresh(uid, to_include, cache):
       logger.info(f"Cache hit: submission user_id={uid}")
       return False
     elif not cache_status:
-      cache_status = " (stale)"
+      reason = get_staleness_reason(submission)
+      cache_status = f" (stale: {reason})" if reason else " (stale)"
 
   logger.info(f"Cache miss{cache_status}: submission user_id={uid}")
   return True
@@ -1027,7 +1202,11 @@ for _, included in self.__cache.values():
   to_include |= included
 
 if self.__all_fetched:
-  logger.info(f"Using cached submissions for assignment id={self.id}")
+  cache_age = datetime.now() - self.__all_fetched
+  logger.info(f"Using cached submissions for assignment id={self.id}: "
+              f"{len(self.__cache)} submissions cached "
+              f"(age: {cache_age.total_seconds()/60:.1f} minutes), "
+              f"checking staleness to decide refresh strategy")
   num_needs_refresh = 0
   for submission, included in self.__cache.values():
     if must_refresh(submission.user_id, to_include, self.__cache):


### PR DESCRIPTION
## Summary

Improves cache diagnostic logging in `canvaslms.hacks.canvasapi` to provide complete transparency about why cache refreshes occur. This makes debugging cache issues significantly easier and helps tune cache TTL values.

## Changes

### Part 1: Cache Staleness Diagnostics
- **TTL constants**: Define SUBMISSION_TTL_MINUTES (5), DEFAULT_CACHE_TTL_DAYS (7), USER_CACHE_TTL_DAYS (2), GROUP_CACHE_TTL_DAYS (5)
- **get_staleness_reason()**: New diagnostic function returning human-readable staleness explanations
- **Enhanced logging**: Cache miss, individual refresh, and invalidation messages now explain WHY refreshes occur
- **Constants usage**: All TTL values reference constants, ensuring log messages stay synchronized with behavior

### Part 2: Bulk Refresh Transparency
- **Kwargs invalidation logging**: Shows when new include fields trigger cache invalidation
- **Bulk fetch trigger logging**: Distinguishes first fetch vs cache invalidation scenarios
- **Cached path logging**: Shows cache age, size, and stale count when using cached data
- **Literate narrative**: Comprehensive documentation of cache decision logging strategy

## Benefits

1. **Debuggability**: Clear logs explain WHY refreshes occur (first fetch, TTL expiry, kwargs change)
2. **Performance insights**: Cache age and staleness counts reveal cache effectiveness
3. **Consistency**: Same diagnostic transparency for all cache types (submissions, courses, users, assignments)
4. **Maintainability**: Constants ensure log messages automatically update when TTL values are tuned

## Example Output

**Before:**
```
Cache miss (stale): assignment id=123 fetched in 0.5s
Bulk refresh: 45 assignments in 2.1s
```

**After:**
```
Cache invalidation: assignment_all_fetched periodic refresh (age: 8 days, threshold: 7 days)
Cache miss (stale: periodic refresh: assignment_all_fetched (age: 8 days, threshold: 7 days)): assignment id=123 fetched in 0.5s
Bulk fetch: assignments - cache invalidated
Merging kwargs for assignment: extending include fields from ['submission'] to ['rubric', 'submission'] (added: ['rubric'])
Bulk refresh completed: 45 assignments fetched in 2.1s (API: 1.8s, processing: 0.3s)
```

## Testing

- [x] Code regenerated with `make -C src/canvaslms/hacks all`
- [x] No syntax errors (Black formatting passed)
- [x] Only .nw source file committed (not generated .py/.tex files)
- [ ] Runtime testing with actual Canvas API calls (requires Canvas instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)