### PR TITLE
Add --html option to pages view and edit subcommands

### DIFF
--- a/src/canvaslms/cli/content.nw
+++ b/src/canvaslms/cli/content.nw
@@ -618,6 +618,39 @@ def render_to_markdown(obj, schema, content_attr='message', extra_attributes=Non
 
 @
 
+\subsection{Rendering to HTML}
+
+Sometimes we need to preserve the original HTML content rather than converting it
+to Markdown. This is useful when pages contain elements that don't convert well:
+embedded videos, iframes, complex tables, or custom HTML formatting. The
+[[render_to_html]] function is the counterpart to [[render_to_markdown]]---it
+produces the same YAML front matter format, but leaves the body as raw HTML.
+<<rendering functions>>=
+def render_to_html(obj, schema, content_attr='message', extra_attributes=None):
+    """Render a Canvas object to HTML with YAML front matter.
+
+    Unlike render_to_markdown, this outputs the HTML content as-is,
+    without converting to Markdown. Use this when HTML elements must
+    be preserved exactly (embedded videos, iframes, custom formatting).
+
+    Args:
+        obj: Canvas API object
+        schema: Schema for attribute extraction
+        content_attr: Name of the attribute containing HTML content
+        extra_attributes: Optional dict of additional attributes
+
+    Returns:
+        String with YAML front matter and HTML body
+    """
+    attributes = extract_attributes_from_object(obj, schema)
+    if extra_attributes:
+        attributes.update(extra_attributes)
+
+    html_content = getattr(obj, content_attr, '') or ''
+    return format_yaml_front_matter(attributes, html_content)
+
+@
+
 \subsection{Verifying rendering}
 <<test rendering functions>>=
 class TestRenderToMarkdown:
@@ -668,6 +701,37 @@ class TestRenderToMarkdown:
         assert "modules:" in result
         assert "- Week 1" in result
         assert "- Week 2" in result
+
+
+class TestRenderToHtml:
+    """Tests for render_to_html function."""
+
+    def test_preserves_html_content(self):
+        """HTML content is preserved without conversion."""
+        class MockPage:
+            title = "Video Page"
+            body = '<iframe src="https://example.com/video"></iframe>'
+
+        schema = {
+            'title': {'default': '', 'required': True, 'canvas_attr': 'title'},
+        }
+        result = content.render_to_html(MockPage(), schema, 'body')
+        assert result.startswith("---\n")
+        assert "title: Video Page" in result
+        # HTML should be preserved exactly
+        assert '<iframe src="https://example.com/video"></iframe>' in result
+
+    def test_handles_empty_content(self):
+        """Empty content attribute produces empty body."""
+        class MockPage:
+            title = "Empty"
+            body = ""
+
+        schema = {
+            'title': {'default': '', 'required': True, 'canvas_attr': 'title'},
+        }
+        result = content.render_to_html(MockPage(), schema, 'body')
+        assert "title: Empty" in result
 
 @
 

--- a/src/canvaslms/cli/pages.nw
+++ b/src/canvaslms/cli/pages.nw
@@ -26,6 +26,7 @@ import sys
 import pypandoc
 import rich.console
 import rich.markdown
+import rich.syntax
 
 import canvaslms.cli
 import canvaslms.cli.content
@@ -148,13 +149,33 @@ def pages_list_command(config, canvas, args):
 The [[view]] subcommand displays detailed page content. When output is a TTY,
 it shows rich formatting with a pager. When piped, it outputs YAML front matter
 plus Markdown suitable for editing and pushing back with [[edit -f]].
+
+\subsection{The [[--html]] option}
+
+By default, [[view]] converts page content from HTML to Markdown for easier
+reading and editing. However, some pages contain elements that don't convert
+well to Markdown: embedded videos, iframes, complex tables, or custom HTML
+formatting. The [[--html]] option preserves the original HTML content.
+
+When [[--html]] is specified:
+\begin{description}
+\item[TTY output] Shows syntax-highlighted HTML in the pager
+\item[Piped output] Outputs YAML front matter plus raw HTML body
+\end{description}
+
+This enables a round-trip workflow where HTML pages can be viewed, edited, and
+pushed back without losing any formatting.
 <<add pages view subcommand>>=
 view_parser = pages_subp.add_parser("view",
     help="View page content",
     description="View wiki page content. When piped, outputs editable format "
-      "with YAML front matter.")
+      "with YAML front matter. Use --html to preserve HTML instead of "
+      "converting to Markdown.")
 view_parser.set_defaults(func=pages_view_command)
 add_page_options(view_parser)
+view_parser.add_argument("--html",
+    action="store_true",
+    help="Output raw HTML instead of converting to Markdown")
 @
 
 <<functions>>=
@@ -167,11 +188,17 @@ def pages_view_command(config, canvas, args):
     <<fetch full page content>>
 
     if sys.stdout.isatty():
-      output = format_page(full_page)
-      with console.pager(styles=False, links=True):
-        console.print(rich.markdown.Markdown(output, code_theme="manni"))
+      if args.html:
+        <<output page html in tty>>
+      else:
+        output = format_page(full_page)
+        with console.pager(styles=False, links=True):
+          console.print(rich.markdown.Markdown(output, code_theme="manni"))
     else:
-      <<output page in editable format>>
+      if args.html:
+        <<output page in html format>>
+      else:
+        <<output page in editable format>>
 @
 
 \subsection{Editable output format}
@@ -205,6 +232,49 @@ modules module. Pages are identified by their URL slug.
 <<get current modules for page>>=
 page_modules = canvaslms.cli.modules.get_item_modules(
     full_page.course, 'Page', full_page.url)
+@
+
+\subsection{HTML output format}
+
+When [[--html]] is specified, we preserve the original HTML content instead of
+converting to Markdown. This is the counterpart to the editable format above.
+
+For TTY output, we display the HTML with syntax highlighting. We show a header
+with metadata first (same as the Markdown view), then the raw HTML body with
+syntax highlighting for readability.
+<<output page html in tty>>=
+header = f"# {full_page.title}\n\n"
+header += f"## Metadata\n\n"
+header += f"- Course: {full_page.course.course_code}\n"
+header += f"- Published: {'Yes' if full_page.published else 'No'}\n"
+header += f"- URL: {full_page.html_url}\n"
+if hasattr(full_page, 'front_page') and full_page.front_page:
+  header += f"- Front page: Yes\n"
+if hasattr(full_page, 'editing_roles'):
+  header += f"- Editing roles: {full_page.editing_roles}\n"
+header += "\n## Content (HTML)\n\n"
+
+with console.pager(styles=True):
+  console.print(rich.markdown.Markdown(header))
+  if hasattr(full_page, 'body') and full_page.body:
+    syntax = rich.syntax.Syntax(full_page.body, "html", theme="monokai",
+                                word_wrap=True)
+    console.print(syntax)
+  else:
+    console.print("(No content)")
+@
+
+For piped output, we use [[render_to_html]] from the content module to produce
+YAML front matter with the raw HTML body. This can be saved to a file, edited,
+and pushed back using [[pages edit --html -f]].
+<<output page in html format>>=
+<<get current modules for page>>
+output = canvaslms.cli.content.render_to_html(
+    full_page,
+    canvaslms.cli.content.PAGE_SCHEMA,
+    content_attr='body',
+    extra_attributes={'modules': page_modules})
+print(output)
 @
 
 The page object returned by [[get_pages()]] doesn't include the body content.
@@ -264,13 +334,18 @@ edit_parser = pages_subp.add_parser("edit",
       "With -f, reads from a Markdown file with YAML front matter and updates "
       "directly (script-friendly). If the YAML contains a 'url' field, the "
       "command uses it to identify the page; use --create to create a new page "
-      "if the URL is not found.")
+      "if the URL is not found. Use --html to read/edit HTML directly without "
+      "Markdown conversion.")
 edit_parser.set_defaults(func=pages_edit_command)
 add_page_options(edit_parser, required=True)
 canvaslms.cli.content.add_file_option(edit_parser)
 edit_parser.add_argument("--create",
     action="store_true",
     help="Create a new page if the URL in the YAML is not found")
+edit_parser.add_argument("--html",
+    action="store_true",
+    help="Read file as HTML instead of converting from Markdown. "
+         "In interactive mode, edit HTML directly.")
 @
 
 <<functions>>=
@@ -292,10 +367,12 @@ This mode is script-friendly and does not require user interaction.
 @
 
 We read the file using the content module's infrastructure, then validate the
-attributes against the page schema.
+attributes against the page schema. The body content may be Markdown (default)
+or HTML (when [[--html]] is specified).
 <<read and validate page content from file>>=
 try:
-  attributes, markdown_content = canvaslms.cli.content.read_content_from_file(args.file)
+  # body_content is Markdown or HTML depending on args.html
+  attributes, body_content = canvaslms.cli.content.read_content_from_file(args.file)
 except FileNotFoundError:
   logger.error(f"File not found: {args.file}")
   print(f"Error: File not found: {args.file}", file=sys.stderr)
@@ -315,8 +392,9 @@ if errors:
 
 \subsection{Updating pages with new content}
 
-We convert the Markdown content to HTML for Canvas and build the update
-dictionary. The Canvas API expects page updates with a [[wiki_page]] wrapper.
+We convert the content to HTML for Canvas (unless [[--html]] is specified, in
+which case the content is already HTML) and build the update dictionary. The
+Canvas API expects page updates with a [[wiki_page]] wrapper.
 
 If the YAML front matter contains a [[url]] field, we use it to identify the
 specific page to update. This enables a Git-based workflow where the page can
@@ -326,7 +404,10 @@ be reliably identified even if the title changes. If the URL is not found and
 If no [[url]] is in the YAML, we fall back to the filter-based matching using
 [[-p]] and [[-M]] options (the existing behavior).
 <<update pages with new content>>=
-html_content = pypandoc.convert_text(markdown_content, 'html', format='md')
+if args.html:
+  html_content = body_content  # Already HTML, no conversion needed
+else:
+  html_content = pypandoc.convert_text(body_content, 'html', format='md')
 
 if 'url' in attributes and attributes['url']:
   <<update or create page by url>>
@@ -566,18 +647,66 @@ We open the user's editor with the current content. By specifying
 from the attributes, converts HTML to Markdown, and excludes it from the YAML
 front matter. We include the [[modules]] attribute so users can edit module
 membership.
+
+When [[--html]] is specified, we need a different approach: we open the editor
+with the raw HTML content and skip the HTML-to-Markdown conversion. We do this
+by not specifying [[content_attr]], instead manually including the body in the
+initial content.
 <<open editor with page content>>=
-result = canvaslms.cli.content.get_content_from_editor(
-    canvaslms.cli.content.PAGE_SCHEMA,
-    current_attrs,
-    content_attr='body',
-    extra_attributes={'modules': page_modules})
+if args.html:
+  <<open editor with html content>>
+else:
+  result = canvaslms.cli.content.get_content_from_editor(
+      canvaslms.cli.content.PAGE_SCHEMA,
+      current_attrs,
+      content_attr='body',
+      extra_attributes={'modules': page_modules})
 if result is None:
   print("Editor cancelled. Skipping this page.", file=sys.stderr)
   skipped_count += 1
   continue
 
-attributes, markdown_content = result
+# body_content is Markdown or HTML depending on args.html
+attributes, body_content = result
+@
+
+For HTML mode, we build the editor content manually: YAML front matter with
+page attributes, followed by the raw HTML body. We remove [[body]] from the
+attributes since it becomes the document content after the front matter.
+<<open editor with html content>>=
+import tempfile
+import subprocess
+import os
+
+editor = os.environ.get('EDITOR', 'nano')
+
+# Build initial content: YAML front matter + HTML body
+html_attrs = current_attrs.copy()
+html_body = html_attrs.pop('body', '') or ''
+html_attrs['modules'] = page_modules
+
+initial_content = canvaslms.cli.content.format_yaml_front_matter(
+    html_attrs, html_body)
+
+with tempfile.NamedTemporaryFile(mode='w+', suffix='.html', delete=False) as f:
+  f.write(initial_content)
+  temp_path = f.name
+
+try:
+  subprocess.run([editor, temp_path], check=True)
+  with open(temp_path, 'r') as f:
+    edited_content = f.read()
+  attributes, html_body = canvaslms.cli.content.parse_yaml_front_matter(
+      edited_content)
+  result = (attributes, html_body.strip())
+except Exception as e:
+  logger.error(f"Error opening editor: {e}")
+  result = None
+finally:
+  try:
+    os.unlink(temp_path)
+  except OSError:
+    pass
 @
 
 After editing, we enter the interactive confirm loop. The user can preview the
@@ -585,7 +714,7 @@ content, accept it (which triggers the update), edit further, or discard changes
 <<interactive confirm and update single page>>=
 title = attributes.get('title', full_page.title)
 result = canvaslms.cli.content.interactive_confirm_and_edit(
-    title, markdown_content, attributes,
+    title, body_content, attributes,
     canvaslms.cli.content.PAGE_SCHEMA, "Page")
 
 if result is None:
@@ -597,13 +726,17 @@ final_attrs, final_content = result
 <<update single page from interactive edit>>
 @
 
-When the user accepts, we convert the Markdown to HTML and update the page.
+When the user accepts, we convert the Markdown to HTML (unless [[--html]] is
+specified, in which case the content is already HTML) and update the page.
 <<update single page from interactive edit>>=
-try:
-  html_content = pypandoc.convert_text(final_content, 'html', format='md')
-except Exception as e:
-  logger.warning(f"Failed to convert markdown to HTML: {e}")
-  html_content = final_content
+if args.html:
+  html_content = final_content  # Already HTML, no conversion needed
+else:
+  try:
+    html_content = pypandoc.convert_text(final_content, 'html', format='md')
+  except Exception as e:
+    logger.warning(f"Failed to convert markdown to HTML: {e}")
+    html_content = final_content
 
 update_data = {
   'wiki_page': {


### PR DESCRIPTION
Enable direct HTML editing for pages with embedded videos, iframes,
or other elements that don't convert well to Markdown. The option:

- view --html: Outputs raw HTML with syntax highlighting (TTY) or
  YAML front matter + HTML body (piped)
- edit --html -f: Reads HTML file directly without Markdown conversion
- edit --html: Opens editor with raw HTML for interactive editing

Also adds render_to_html() function to content module as counterpart
to render_to_markdown().

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
