### PR TITLE
Completes quizzes functionality

### DIFF
--- a/src/canvaslms/cli/quizzes.nw
+++ b/src/canvaslms/cli/quizzes.nw
@@ -2904,6 +2904,10 @@ def items_list_command(config, canvas, args):
 
 \subsection{Listing New Quiz items}
 
+For New Quizzes, we call the items endpoint and normalize the response into a
+consistent format with [[position]], [[id]], [[type]], [[title]], and [[points]]
+fields.
+
 <<functions>>=
 def list_new_quiz_items(course, assignment_id, requester):
   """Lists items in a New Quiz
@@ -2944,6 +2948,9 @@ def list_new_quiz_items(course, assignment_id, requester):
 
 
 \subsection{Listing Classic Quiz questions}
+
+For Classic Quizzes, we use the [[get_questions()]] method from the canvasapi
+library and normalize the response to match the same format as New Quiz items.
 
 <<functions>>=
 def list_classic_questions(quiz):
@@ -4086,6 +4093,10 @@ def items_edit_command(config, canvas, args):
 
 \subsection{Updating a New Quiz item}
 
+The New Quizzes API uses PATCH requests with form-encoded parameters.  For
+nested structures like [[entry]], we flatten the keys using bracket notation
+(e.g., [[item[entry][title]]]).
+
 <<functions>>=
 def update_new_quiz_item(course, assignment_id, item_id, requester, update_data):
   """Updates an item in a New Quiz
@@ -4130,6 +4141,9 @@ def update_new_quiz_item(course, assignment_id, item_id, requester, update_data)
 
 
 \subsection{Updating a Classic Quiz question}
+
+Classic Quizzes use the canvasapi library's [[edit()]] method, which handles
+the API call internally.
 
 <<functions>>=
 def update_classic_question(quiz, question_id, update_data):
@@ -4219,6 +4233,8 @@ def items_delete_command(config, canvas, args):
 
 \subsection{Deleting a New Quiz item}
 
+The New Quizzes API uses DELETE requests to the item endpoint.
+
 <<functions>>=
 def delete_new_quiz_item(course, assignment_id, item_id, requester):
   """Deletes an item from a New Quiz
@@ -4248,6 +4264,8 @@ def delete_new_quiz_item(course, assignment_id, item_id, requester):
 
 
 \subsection{Deleting a Classic Quiz question}
+
+Classic Quizzes use the canvasapi library's [[delete()]] method.
 
 <<functions>>=
 def delete_classic_question(quiz, question_id):
@@ -4909,6 +4927,10 @@ def banks_export_command(config, canvas, args):
 
 
 \subsection{Fetching bank items}
+
+We fetch items from an item bank using the [[item_banks]] API endpoint.  This
+endpoint may not be accessible in all Canvas configurations, so we handle
+failures gracefully.
 
 <<functions>>=
 def get_bank_items(requester, bank_id):


### PR DESCRIPTION
- **Add quiz CRUD commands and items export with bank expansion**
- **Add --example flag to quizzes items add command**
- **Expand --example to include all 9 working question types**
- **Add Classic Quiz question type documentation and expand examples**
- **Add --importable flag to export for clean import-ready JSON**
- **Document UUID handling in --importable export**
- **Improve prose for UUID handling and cleaning functions**
- **Add prose for helper functions in quizzes module**
