### PR TITLE
Fix pages edit -f overwriting all pages when no url in YAML

### DIFF
--- a/src/canvaslms/cli/pages.nw
+++ b/src/canvaslms/cli/pages.nw
@@ -403,8 +403,9 @@ specific page to update. This enables a Git-based workflow where the page can
 be reliably identified even if the title changes. If the URL is not found and
 [[--create]] is specified, we create a new page instead.
 
-If no [[url]] is in the YAML, we fall back to the filter-based matching using
-[[-p]] and [[-M]] options (the existing behavior).
+If no [[url]] is in the YAML, we try title-based matching first (using the
+[[title]] field from the front matter), then fall back to filter-based matching
+using [[-p]] and [[-M]] options only if no title is specified.
 <<update pages with new content>>=
 if args.html:
   html_content = body_content  # Already HTML, no conversion needed
@@ -515,18 +516,65 @@ if 'modules' in attributes:
     print(f"  Added to modules: {', '.join(added)}", file=sys.stderr)
 @
 
+\subsubsection{Title-based page identification}
+
+When no [[url]] is specified in the YAML but a [[title]] is present, we use the
+title to find the page. This is the most common case when creating or updating
+pages from Markdown files: the user specifies a title in the front matter and
+expects the command to find or create a page with that title.
+
+We use exact title matching (not regex) to avoid accidentally updating multiple
+pages. If exactly one page matches, we update it. If no pages match and
+[[--create]] is specified, we create a new page. If multiple pages match, we
+report an error---the user should add a [[url]] field to disambiguate.
+<<update or create page by title>>=
+title = attributes['title']
+course_list = canvaslms.cli.courses.process_course_option(canvas, args)
+if not course_list:
+  print("Error: No courses found matching criteria", file=sys.stderr)
+  return
+
+course = course_list[0]
+
+matching_pages = [p for p in course.get_pages() if p.title == title]
+
+if len(matching_pages) == 1:
+  full_page = course.get_page(matching_pages[0].url)
+  full_page.course = course
+  <<update existing page>>
+elif len(matching_pages) == 0:
+  if args.create:
+    <<create new page>>
+  else:
+    print(f"Error: Page '{title}' not found. "
+          f"Use --create to create a new page.", file=sys.stderr)
+    return
+else:
+  print(f"Error: Multiple pages with title '{title}' found. "
+        f"Add 'url' field to YAML to identify specific page.", file=sys.stderr)
+  return
+@
+
 \subsubsection{Filter-based page matching}
 
-When no URL is specified in the YAML, we use the filter options ([[-p]], [[-M]])
-to find matching pages. This maintains backwards compatibility with the original
-behavior.
+When neither [[url]] nor [[title]] is specified in the YAML, we fall back to the
+filter options ([[-p]], [[-M]]) to find matching pages. This is a rare case but
+maintains backwards compatibility. We add a safety check: if multiple pages
+match, we report an error rather than updating all of them.
 <<update pages by filter matching>>=
-pages = process_page_option(canvas, args)
-
-for page in pages:
-  full_page = page.course.get_page(page.url)
-  full_page.course = page.course
-  <<update existing page>>
+if 'title' in attributes and attributes['title']:
+  <<update or create page by title>>
+else:
+  pages = process_page_option(canvas, args)
+  if len(pages) > 1:
+    print(f"Error: {len(pages)} pages match filter. "
+          f"Add 'title' or 'url' to YAML, or use -p to narrow selection.",
+          file=sys.stderr)
+    return
+  for page in pages:
+    full_page = page.course.get_page(page.url)
+    full_page.course = page.course
+    <<update existing page>>
 @
 
 We add optional attributes only if they are present in the YAML front matter.


### PR DESCRIPTION
When using 'pages edit -f <file>' with a file that lacked a 'url' field
in the YAML front matter, the command would fall back to filter-based
matching with the default -p '.*' pattern, matching ALL pages and
overwriting them with the file's content.

Now the command uses the 'title' field from YAML for exact matching:
- If exactly one page matches the title, update it
- If no pages match and --create is specified, create new page
- If no pages match without --create, error with helpful message
- If multiple pages match, error asking for 'url' field to disambiguate
- Fall back to filter matching only if no title in YAML (with safety
  check to prevent updating multiple pages)
