### PR TITLE
Add quizzes export command and improve create documentation

### DIFF
--- a/src/canvaslms/cli/quizzes.nw
+++ b/src/canvaslms/cli/quizzes.nw
@@ -5568,10 +5568,28 @@ EXAMPLE_FULL_NEW_QUIZ_JSON = {
     "unlock_at": None,
     "lock_at": None,
     "quiz_settings": {
+      # Randomization settings
       "shuffle_answers": True,
       "shuffle_questions": False,
+
+      # Time limit settings
       "has_time_limit": True,
       "session_time_limit_in_seconds": 1800,
+
+      # Question display settings
+      "one_at_a_time_type": "none",
+      "allow_backtracking": True,
+
+      # Calculator settings
+      "calculator_type": "none",
+
+      # Access restrictions
+      "filter_ip_address": False,
+      "filters": {},
+      "require_student_access_code": False,
+      "student_access_code": None,
+
+      # Multiple attempts settings
       "multiple_attempts": {
         "multiple_attempts_enabled": True,
         "attempt_limit": False,
@@ -5580,6 +5598,8 @@ EXAMPLE_FULL_NEW_QUIZ_JSON = {
         "cooling_period": True,
         "cooling_period_seconds": 3600
       },
+
+      # Result view settings - what students see after submission
       "result_view_settings": {
         "result_view_restricted": True,
         "display_points_awarded": True,
@@ -5589,7 +5609,9 @@ EXAMPLE_FULL_NEW_QUIZ_JSON = {
         "display_item_response_qualifier": "always",
         "display_item_response_correctness": True,
         "display_item_correct_answer": False,
-        "display_item_feedback": False
+        "display_item_feedback": False,
+        "display_correct_answer_at": None,
+        "hide_correct_answer_at": None
       }
     }
   },
@@ -5764,32 +5786,59 @@ def print_full_quiz_example_json():
   print()
   print("This is the same format produced by 'quizzes export -I'.")
   print()
-  print("Basic settings (time_limit in SECONDS for New Quizzes):")
-  print("  title, instructions, time_limit, allowed_attempts,")
-  print("  shuffle_questions, shuffle_answers, points_possible,")
-  print("  due_at, unlock_at, lock_at")
+  print("BASIC SETTINGS:")
+  print("  title              - Quiz title")
+  print("  instructions       - HTML instructions shown to students")
+  print("  time_limit         - Time limit in SECONDS (or null)")
+  print("  points_possible    - Total points")
+  print("  due_at/unlock_at/lock_at - ISO 8601 dates (or null)")
   print()
-  print("Advanced settings (in 'settings.quiz_settings'):")
+  print("QUIZ SETTINGS (in 'settings.quiz_settings'):")
   print()
-  print("  multiple_attempts - Controls retake behavior:")
+  print("  Randomization:")
+  print("    shuffle_answers: true/false - Randomize answer order")
+  print("    shuffle_questions: true/false - Randomize question order")
+  print()
+  print("  Time limit:")
+  print("    has_time_limit: true/false")
+  print("    session_time_limit_in_seconds: number")
+  print()
+  print("  Question display:")
+  print("    one_at_a_time_type: 'none' or 'question'")
+  print("    allow_backtracking: true/false - Can go back to previous questions")
+  print()
+  print("  Calculator:")
+  print("    calculator_type: 'none', 'basic', or 'scientific'")
+  print()
+  print("  Access restrictions:")
+  print("    require_student_access_code: true/false")
+  print("    student_access_code: 'password' or null")
+  print("    filter_ip_address: true/false")
+  print("    filters: {} or IP filter rules")
+  print()
+  print("  Multiple attempts:")
   print("    multiple_attempts_enabled: true/false")
-  print("    attempt_limit: number or null for unlimited")
+  print("    attempt_limit: true/false (true = limited, false = unlimited)")
+  print("    max_attempts: number or null")
   print("    score_to_keep: 'highest' or 'latest'")
   print("    cooling_period: true/false (require wait between attempts)")
-  print("    cooling_period_seconds: seconds to wait (e.g., 3600 = 1 hour)")
+  print("    cooling_period_seconds: seconds (e.g., 3600 = 1 hour)")
   print()
-  print("  result_view_settings - Controls what students see after submit:")
-  print("    display_items: show questions (true/false)")
-  print("    display_item_response: show student's answers (true/false)")
-  print("    display_item_correct_answer: show correct answers (true/false)")
-  print("    display_item_feedback: show per-question feedback (true/false)")
-  print("    display_points_awarded: show points per question (true/false)")
-  print("    display_points_possible: show max points (true/false)")
-  print("    display_correct_answer_at: ISO date to reveal answers (or null)")
-  print("    hide_correct_answer_at: ISO date to hide answers (or null)")
+  print("  Result view (what students see after submission):")
+  print("    result_view_restricted: true/false")
+  print("    display_items: true/false - Show questions")
+  print("    display_item_response: true/false - Show student's answers")
+  print("    display_item_response_correctness: true/false - Show right/wrong")
+  print("    display_item_correct_answer: true/false - Show correct answers")
+  print("    display_item_feedback: true/false - Show per-question feedback")
+  print("    display_points_awarded: true/false - Show points earned")
+  print("    display_points_possible: true/false - Show max points")
+  print("    display_correct_answer_at: ISO date or null - When to reveal")
+  print("    hide_correct_answer_at: ISO date or null - When to hide")
   print()
-  print("Note: UUIDs in choices must be unique. Generate with:")
-  print("  python -c 'import uuid; print(uuid.uuid4())'")
+  print("SCORING:")
+  print("  Use position numbers (1, 2, 3...) to reference correct answers.")
+  print("  UUIDs are generated automatically during import.")
   print()
   print(json.dumps(EXAMPLE_FULL_NEW_QUIZ_JSON, indent=2))
   print()


### PR DESCRIPTION
- Add 'quizzes export' command that exports complete quiz (settings + questions)
  to JSON format for backup and migration between courses
- Add --example flag to 'quizzes create' showing full JSON format
- Update 'quizzes create' to accept questions in JSON for single-file import
- Improve help text with comprehensive attribute documentation
- Update chapter introduction with all subcommands and workflow examples
- Add EXAMPLE_FULL_NEW_QUIZ_JSON and EXAMPLE_FULL_CLASSIC_QUIZ_JSON constants

Workflow:
  canvaslms quizzes export -c "Source" -a "Quiz" -I > quiz.json
  canvaslms quizzes create -c "Target" -f quiz.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
