### PR TITLE
Normalize must-fix grades to F

### DIFF
--- a/src/canvaslms/cli/results.nw
+++ b/src/canvaslms/cli/results.nw
@@ -61,6 +61,7 @@ verify.
 """Tests for canvaslms.cli.results."""
 import argparse
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import canvasapi.exceptions
 
@@ -803,20 +804,23 @@ elif submission.grade is None:
   else:
     yield user, assignment, "not done"
 else:
+  grade = submission.grade
+  if normalize_grade is not None:
+    grade = normalize_grade(grade)
   <<check if grade passes using callback or regex>>
   if not grade_passes:
     if submission.submitted_at and submission.graded_at and \
           submission.submitted_at > submission.graded_at:
       yield user, assignment, \
-            f"not a passing grade ({submission.grade}), resubmission not graded"
+            f"not a passing grade ({grade}), resubmission not graded"
     else:
       yield user, assignment, \
-            f"not a passing grade ({submission.grade})"
+            f"not a passing grade ({grade})"
 <<check if grade passes using callback or regex>>=
 if is_passing is not None:
-  grade_passes = is_passing(submission.grade)
+  grade_passes = is_passing(grade)
 else:
-  grade_passes = filter_grade(submission.grade, passing_regex)
+  grade_passes = filter_grade(grade, passing_regex)
 @
 
 Now, we need that [[passing_regex]], so we can add it to the optional
@@ -840,6 +844,48 @@ This lets grading modules define their own semantics for what constitutes a
 passing grade.
 <<optional [[missing_assignments]] args>>=
 is_passing=None,
+@
+
+Some grading modules need to collapse Canvas-specific labels into the grade
+tokens used by their own summaries before the shared helper decides whether a
+grade passes.
+<<optional [[missing_assignments]] args>>=
+normalize_grade=None,
+@
+
+The normalization callback should affect both the pass/fail decision and the
+reported reason string.
+<<test functions>>=
+class TestMissingAssignments:
+    """Test default missing-assignment reporting helpers."""
+
+    def test_normalize_grade_callback_applies_before_passing_check(self):
+        """Normalized grades should drive both pass/fail and messages."""
+        user = SimpleNamespace(login_id="student1")
+        assignment = SimpleNamespace(name="Lab 1")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at=None,
+                graded_at="2026-01-10T10:00:00Z",
+            )
+        )
+
+        missing = list(
+            missing_assignments(
+                [assignment],
+                [user],
+                is_passing=lambda grade: grade != "F",
+                normalize_grade=lambda grade: (
+                    "F" if grade.casefold() == "must fix" else grade
+                ),
+            )
+        )
+
+        assert len(missing) == 1
+        assert missing[0][0] is user
+        assert missing[0][1] is assignment
+        assert missing[0][2] == "not a passing grade (F)"
 @
 
 This allows us to make the call to the function as follows.

--- a/src/canvaslms/grades/conjunctavg.nw
+++ b/src/canvaslms/grades/conjunctavg.nw
@@ -39,6 +39,18 @@ def summarize_group(assignments_list, users_list):
     yield [user, grade, grade_date, *graders]
 @
 
+We define the test file structure early, then add the focused regressions near
+the grade handling they verify.
+<<test [[conjunctavg.py]]>>=
+"""Tests for canvaslms.grades.conjunctavg."""
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from canvaslms.grades.conjunctavg import *
+
+<<test functions>>
+@
+
 
 \subsection{Summarizing grades: assignment grades to component grade}
 
@@ -53,6 +65,19 @@ the summarized grade will be an F.
 If we find no Fs, then we can compute the average over all A--E grades and use 
 that as the final grade.
 We translate completes to Ps and incompletes to Fs.
+Canvas also sometimes reports the failing label [[must fix]].
+For conjunctive grading that label carries no extra information beyond failure,
+so we normalize it to [[F]] before classifying the grade.
+<<helper functions>>=
+def normalize_grade(grade):
+  """Normalize Canvas failing aliases to this module's grade tokens."""
+  if grade is None:
+    return "F"
+  if isinstance(grade, str) and grade.casefold() == "must fix":
+    return "F"
+  return grade
+@
+
 <<helper functions>>=
 def summarize(user, assignments_list):
   """
@@ -109,10 +134,7 @@ if grade_date:
 We extract the grade and then try to figure out which grading scale is used.
 Then we translate, if necessary, and add it to the proper list.
 <<add grade to the correct grades list>>=
-grade = submission.grade
-
-if grade is None:
-  grade = "F"
+grade = normalize_grade(submission.grade)
 
 if grade in ["A", "B", "C", "D", "E"]:
   a2e_grades.append(grade)
@@ -173,8 +195,7 @@ def is_passing_grade(grade):
   """
   Returns True if grade is passing for conjunctive A-E grading.
   """
-  if grade is None:
-    return False
+  grade = normalize_grade(grade)
   if grade in ["A", "B", "C", "D", "E", "P"]:
     return True
   if isinstance(grade, str) and grade.casefold() == "complete":
@@ -198,7 +219,52 @@ def missing_assignments(assignments_list, users_list,
   return results.missing_assignments(
     assignments_list, users_list,
     optional_assignments=optional_assignments,
-    is_passing=is_passing_grade
+    is_passing=is_passing_grade,
+    normalize_grade=normalize_grade
   )
 @
 
+The missing-assignment report should use the same normalized grade vocabulary as
+the summary itself.
+<<test functions>>=
+class TestMustFixGrade:
+    """Test normalization of the Canvas [[must fix]] grade."""
+
+    def test_summarize_treats_must_fix_as_f(self):
+        """A [[must fix]] grade should contribute the ordinary failing grade."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Lab 1")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at="2026-01-10T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+
+        grade, grade_date, graders = summarize(user, [assignment])
+
+        assert grade == "F"
+        assert grade_date is not None
+        assert graders == []
+
+    def test_missing_assignments_reports_normalized_f(self):
+        """Missing-assignment output should collapse [[must fix]] to [[F]]."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Lab 1")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at=None,
+                graded_at="2026-01-10T10:00:00Z",
+            )
+        )
+
+        missing = list(missing_assignments([assignment], [user]))
+
+        assert len(missing) == 1
+        assert missing[0][0] is user
+        assert missing[0][1] is assignment
+        assert missing[0][2] == "not a passing grade (F)"
+@

--- a/src/canvaslms/grades/conjunctavgsurvey.nw
+++ b/src/canvaslms/grades/conjunctavgsurvey.nw
@@ -7,10 +7,7 @@ This is to allow for mandatory surveys that are not graded, but still need to
 be included in the summary.
 So when we translate and add the grades to the proper list, we do this:
 <<add grade to the correct grades list>>=
-grade = submission.grade
-
-if grade is None:
-  grade = "F"
+grade = normalize_grade(submission.grade)
 
 if grade in ["A", "B", "C", "D", "E"]:
   a2e_grades.append(grade)
@@ -40,7 +37,7 @@ mandatory, ungraded surveys.
 """
 
 import datetime as dt
-from canvaslms.grades.conjunctavg import a2e_average
+from canvaslms.grades.conjunctavg import a2e_average, normalize_grade
 from canvaslms.cli import results
 from canvasapi.exceptions import ResourceDoesNotExist
 
@@ -57,6 +54,18 @@ def summarize_group(assignments_list, users_list):
     yield [user, grade, grade_date, *graders]
 @
 
+We define the test file structure early, then place the actual regressions next
+to the grade handling they exercise.
+<<test [[conjunctavgsurvey.py]]>>=
+"""Tests for canvaslms.grades.conjunctavgsurvey."""
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from canvaslms.grades.conjunctavgsurvey import *
+
+<<test functions>>
+@
+
 Now we will describe the [[summarize]] helper function.
 We want to establish three things: the most recent date, a suitable grade and 
 who graded.
@@ -68,6 +77,9 @@ the summarized grade will be an F.
 If we find no Fs, then we can compute the average over all A--E grades and use 
 that as the final grade.
 We translate completes to Ps and incompletes to Fs.
+We also reuse [[normalize_grade()]] from [[conjunctavg]] so the survey variant
+interprets the Canvas label [[must fix]] as the ordinary failing grade [[F]]
+before it applies the extra numeric-pass rule.
 <<helper functions>>=
 def summarize(user, assignments_list):
   """
@@ -142,8 +154,7 @@ def is_passing_grade(grade):
   """
   Returns True if grade is passing (includes numeric grades).
   """
-  if grade is None:
-    return False
+  grade = normalize_grade(grade)
   if grade in ["A", "B", "C", "D", "E", "P"]:
     return True
   if isinstance(grade, str):
@@ -172,7 +183,52 @@ def missing_assignments(assignments_list, users_list,
   return results.missing_assignments(
     assignments_list, users_list,
     optional_assignments=optional_assignments,
-    is_passing=is_passing_grade
+    is_passing=is_passing_grade,
+    normalize_grade=normalize_grade
   )
 @
 
+The survey variant should normalize [[must fix]] in both the summary and the
+missing-assignment output.
+<<test functions>>=
+class TestMustFixGrade:
+    """Test normalization of the Canvas [[must fix]] grade."""
+
+    def test_summarize_treats_must_fix_as_f(self):
+        """A [[must fix]] grade should fail conjunctive survey grading."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Survey 1")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at="2026-01-10T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+
+        grade, grade_date, graders = summarize(user, [assignment])
+
+        assert grade == "F"
+        assert grade_date is not None
+        assert graders == []
+
+    def test_missing_assignments_reports_normalized_f(self):
+        """Missing output should collapse [[must fix]] to [[F]]."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Survey 1")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at=None,
+                graded_at="2026-01-10T10:00:00Z",
+            )
+        )
+
+        missing = list(missing_assignments([assignment], [user]))
+
+        assert len(missing) == 1
+        assert missing[0][0] is user
+        assert missing[0][1] is assignment
+        assert missing[0][2] == "not a passing grade (F)"
+@

--- a/src/canvaslms/grades/disjunctmax.nw
+++ b/src/canvaslms/grades/disjunctmax.nw
@@ -46,6 +46,18 @@ def summarize_group(assignments_list, users_list):
     yield [user, grade, grade_date, *graders]
 @
 
+We define the test file structure early, then add the concrete regressions near
+the grade handling they verify.
+<<test [[disjunctmax.py]]>>=
+"""Tests for canvaslms.grades.disjunctmax."""
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from canvaslms.grades.disjunctmax import *
+
+<<test functions>>
+@
+
 
 \subsection{Summarizing grades: assignment grades to component grade}%
 \label{disjunctmax-summarize}
@@ -57,6 +69,21 @@ For the most recent date, we just add them to a list as we iterate through the
 submissions.
 We do the same for grades, as we iterate through we add any grade to a list.
 In the end we compute the maximums of both lists.
+Canvas can also use the label [[must fix]] for a failing attempt.
+Disjunctive grading only needs to know that the attempt has not yet passed, so
+we normalize that label to [[F]] before ranking the grades.
+A missing submission has the same effect, so the exception path also records
+[[F]].
+<<helper functions>>=
+def normalize_grade(grade):
+  """Normalize Canvas failing aliases before ranking grades."""
+  if grade is None:
+    return "F"
+  if isinstance(grade, str) and grade.casefold() == "must fix":
+    return "F"
+  return grade
+@
+
 <<helper functions>>=
 def summarize(user, assignments_list):
   """Extracts user's submissions for assignments in assingments_list to 
@@ -72,16 +99,13 @@ def summarize(user, assignments_list):
       submission = assignment.get_submission(user,
                                             include=["submission_history"])
     except ResourceDoesNotExist:
-      pf_grades.append("F")
+      grades.append("F")
       continue
 
     submission.assignment = assignment
     graders += results.all_graders(submission)
 
-    grade = submission.grade
-
-    if grade is None:
-      grade = "F"
+    grade = normalize_grade(submission.grade)
 
     grades.append(grade)
 
@@ -122,6 +146,7 @@ def grade_max(grades):
   return None
 
 def grade_to_int(grade):
+  grade = normalize_grade(grade)
   grade_map = {"F": -2, "Fx": -1,
                "P": 0,
                "E": 1, "D": 2, "C": 3, "B": 4, "A": 5}
@@ -177,7 +202,7 @@ def missing_assignments(assignments_list, users_list,
 
       try:
         submission = assignment.get_submission(user)
-        grade = submission.grade or "F"
+        grade = normalize_grade(submission.grade)
       except ResourceDoesNotExist:
         grade = "F"
 
@@ -191,4 +216,75 @@ def missing_assignments(assignments_list, users_list,
       for assignment, grade in grades_with_assignments:
         yield user, assignment, \
               f"not a passing grade ({grade}) - complete any one to pass"
+@
 
+Both summary and missing-assignment reporting should collapse [[must fix]] to
+the ordinary failing grade token.
+<<test functions>>=
+class TestMustFixGrade:
+    """Test normalization of the Canvas [[must fix]] grade."""
+
+    def test_summarize_treats_must_fix_as_f(self):
+        """A [[must fix]] attempt should behave like [[F]]."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Exam")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at="2026-01-10T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+
+        grade, grade_date, graders = summarize(user, [assignment])
+
+        assert grade == "F"
+        assert grade_date is not None
+        assert graders == []
+
+    def test_missing_assignments_reports_normalized_f(self):
+        """Missing output should use the normalized failing grade token."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Exam")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(grade="must fix")
+        )
+
+        missing = list(missing_assignments([assignment], [user]))
+
+        assert len(missing) == 1
+        assert missing[0][0] is user
+        assert missing[0][1] is assignment
+        assert missing[0][2] == \
+            "not a passing grade (F) - complete any one to pass"
+
+
+class TestMissingSubmission:
+    """Test disjunctive handling of missing submissions."""
+
+    def test_summarize_treats_missing_submission_as_f(self):
+        """Missing submissions should behave like failing attempts."""
+        user = SimpleNamespace(id=1)
+        missing_assignment = SimpleNamespace(name="Exam 1")
+        missing_assignment.get_submission = Mock(
+            side_effect=ResourceDoesNotExist("missing submission")
+        )
+        graded_assignment = SimpleNamespace(name="Exam 2")
+        graded_assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="F",
+                submitted_at="2026-01-10T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+
+        grade, grade_date, graders = summarize(
+            user, [missing_assignment, graded_assignment]
+        )
+
+        assert grade == "F"
+        assert grade_date is not None
+        assert graders == []
+@

--- a/src/canvaslms/grades/participation.nw
+++ b/src/canvaslms/grades/participation.nw
@@ -107,6 +107,18 @@ def summarize_group(assignments_list, users_list):
     yield [user, grade, grade_date, *graders]
 @
 
+We define the test file structure early, then add the focused regressions near
+the helpers they verify.
+<<test [[participation.py]]>>=
+"""Tests for canvaslms.grades.participation."""
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from canvaslms.grades.participation import *
+
+<<test functions>>
+@
+
 <<module doc>>=
 Summarizes participation assignments using conjunctive P/F grading.
 All assignments must have 'complete' or '100' for P, otherwise F.
@@ -122,11 +134,23 @@ A grade is considered passing if it is either:
 
 Anything else---including [[incomplete]], [[None]], or a missing
 submission---counts as not passing.
+Canvas can also expose the failing label [[must fix]].
+Participation grading does not distinguish between different failing labels, so
+we normalize that alias to [[F]] before checking whether the assignment passed.
+<<helper functions>>=
+def normalize_grade(grade):
+  """Normalize Canvas failing aliases for participation grading."""
+  if isinstance(grade, str) and grade.casefold() == "must fix":
+    return "F"
+  return grade
+@
+
 <<helper functions>>=
 def is_passing_grade(grade):
   """
   Returns True if the grade indicates passing (complete or 100).
   """
+  grade = normalize_grade(grade)
   if grade is None:
     return False
   if isinstance(grade, str):
@@ -240,6 +264,52 @@ def missing_assignments(assignments_list, users_list,
   return results.missing_assignments(
     assignments_list, users_list,
     optional_assignments=optional_assignments,
-    is_passing=is_passing_grade
+    is_passing=is_passing_grade,
+    normalize_grade=normalize_grade
   )
+@
+
+Both the summary and the missing-assignment output should collapse [[must fix]]
+to the ordinary failing grade token.
+<<test functions>>=
+class TestMustFixGrade:
+    """Test normalization of the Canvas [[must fix]] grade."""
+
+    def test_summarize_treats_must_fix_as_f(self):
+        """A [[must fix]] grade should fail participation grading."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Seminar")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at="2026-01-10T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+
+        grade, grade_date, graders = summarize(user, [assignment])
+
+        assert grade == "F"
+        assert grade_date is not None
+        assert graders == []
+
+    def test_missing_assignments_reports_normalized_f(self):
+        """Missing output should collapse [[must fix]] to [[F]]."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Seminar")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at=None,
+                graded_at="2026-01-10T10:00:00Z",
+            )
+        )
+
+        missing = list(missing_assignments([assignment], [user]))
+
+        assert len(missing) == 1
+        assert missing[0][0] is user
+        assert missing[0][1] is assignment
+        assert missing[0][2] == "not a passing grade (F)"
 @

--- a/src/canvaslms/grades/tilkryLAB1.nw
+++ b/src/canvaslms/grades/tilkryLAB1.nw
@@ -166,6 +166,19 @@ def summarize_group(assignments_list, users_list):
     yield [user, grade, grade_date, *graders]
 @
 
+We define the test file structure early, then add the regressions near the
+grading helpers they verify.
+<<test [[tilkryLAB1.py]]>>=
+"""Tests for canvaslms.grades.tilkryLAB1."""
+import logging
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from canvaslms.grades.tilkryLAB1 import *
+
+<<test functions>>
+@
+
 
 \subsection{Summarizing grades: assignment grades to component grade}
 
@@ -181,6 +194,18 @@ We do the same for grades, as we iterate through we add any grade to either of
 two lists: [[mandatory]] or [[optional]].
 The mandatory assignments have P/F grades.
 The optional assignments have grades between 0 and 2.5.
+Canvas can also report the failing label [[must fix]].
+We normalize that label to [[F]] first so mandatory assignments reuse the
+ordinary failing path, while optional assignments can translate the same failure
+to zero points.
+<<helper functions>>=
+def normalize_grade(grade):
+  """Normalize Canvas failing aliases for the tilkry LAB1 scheme."""
+  if isinstance(grade, str) and grade.casefold() == "must fix":
+    return "F"
+  return grade
+@
+
 <<helper functions>>=
 def summarize(user, assignments_list):
   """
@@ -206,7 +231,7 @@ def summarize(user, assignments_list):
     submission.assignment = assignment
     graders += results.all_graders(submission)
 
-    grade = submission.grade
+    grade = normalize_grade(submission.grade)
 
     <<add [[grade]] to either [[mandatory]] or [[optional]]>>
 
@@ -276,8 +301,13 @@ if not is_optional(assignment):
 If the assignment is optional, we'll add the grade to [[optional]]---if there 
 is any.
 If there is no grade or submission, we'll just skip it.
+A failing grade contributes zero points, which is the optional side's analogue
+of [[F]].
 <<handle optional>>=
 if grade is None:
+  continue
+if grade == "F":
+  optional.append(0.0)
   continue
 try:
   grade = float(grade)
@@ -335,7 +365,7 @@ def missing_assignments(assignments_list, users_list,
         yield user, assignment, "no submission exists"
         continue
 
-      grade = submission.grade
+      grade = normalize_grade(submission.grade)
 
       # Check if mandatory assignment is passed
       if grade is None:
@@ -348,6 +378,60 @@ def missing_assignments(assignments_list, users_list,
       else:
         # Unexpected grade for mandatory assignment
         yield user, assignment, f"unexpected grade ({grade})"
+@
+
+The LAB1 module should accept [[must fix]] without warning and report the
+normalized failing grade in its mandatory-assignment output.
+<<test functions>>=
+class TestMustFixGrade:
+    """Test normalization of the Canvas [[must fix]] grade."""
+
+    def test_optional_must_fix_contributes_no_points_without_warning(
+        self, caplog
+    ):
+        """A failing optional attempt should simply add zero points."""
+        caplog.set_level(logging.WARNING)
+        user = SimpleNamespace(id=1)
+        mandatory = SimpleNamespace(name="Mandatory lab")
+        mandatory.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="P",
+                submitted_at="2026-01-10T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+        optional = SimpleNamespace(name="Optional: Bonus task")
+        optional.get_submission = Mock(
+            return_value=SimpleNamespace(
+                grade="must fix",
+                submitted_at="2026-01-11T10:00:00Z",
+                graded_at=None,
+                submission_history=[],
+            )
+        )
+
+        grade, grade_date, graders = summarize(user, [mandatory, optional])
+
+        assert grade == "E"
+        assert grade_date is not None
+        assert graders == []
+        assert "Invalid grade must fix" not in caplog.text
+
+    def test_missing_assignments_reports_must_fix_as_f(self):
+        """Mandatory [[must fix]] grades should be reported as failing."""
+        user = SimpleNamespace(id=1)
+        assignment = SimpleNamespace(name="Mandatory seminar")
+        assignment.get_submission = Mock(
+            return_value=SimpleNamespace(grade="must fix")
+        )
+
+        missing = list(missing_assignments([assignment], [user]))
+
+        assert len(missing) == 1
+        assert missing[0][0] is user
+        assert missing[0][1] is assignment
+        assert missing[0][2] == "not passed (F)"
 @
 
 


### PR DESCRIPTION
Collapse Canvas's "must fix" label to the ordinary failing grade token across
the grading modules and shared missing-assignment reporting. Add regression
tests so the alias no longer raises parsing errors or leaks inconsistent
failure messages.

Generated with OpenCode (gpt-5.4)
