### PR TITLE
fix lazysubmission assignment after refresh

### DIFF
--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -3577,27 +3577,21 @@ Key design decisions:
 
 \subsubsection{Implementation: LazySubmission class}
 
-The [[LazySubmission]] class wraps a submission object and intercepts
-attribute access using [[__getattribute__]].
+We give the whole picture first, then fill in each method.  The wrapper holds
+the fetched submission together with everything needed to re-fetch it---the
+originating assignment, the [[include]] parameters, and the unwrapped
+[[get_submission]] method---plus the timestamp of the last refresh.  Around that
+state it layers three groups of behaviour: deciding \emph{when} a refresh is due
+([[_needs_refresh]], [[would_need_refresh]]); performing the refresh and
+filling in attributes locally ([[_refresh]], [[ensure_attrs]]); and intercepting
+attribute access so that reads and writes reach the right object
+([[__getattribute__]], [[__setattr__]], [[__getattr__]]).  Two thin string hooks
+and pickle support round out the class.
 
-A transparent proxy has two kinds of attributes to serve, and conflating them
-is a subtle trap.  Most names---[[grade]], [[user_id]], [[body]]---belong to the
-wrapped submission and should be delegated.  But the wrapper also has its own
-behavioural API: the staleness probe [[would_need_refresh]] (and, later, the
-normalisation hook [[ensure_attrs]]).  If [[__getattribute__]] delegates
-\emph{everything} that is not a dunder or underscore-private name, then
-[[lazy.would_need_refresh]] is looked up on the wrapped submission---which has no
-such method---and raises [[AttributeError]].  The bulk-refresh pre-check
-(\cref{sec:bulk-refresh}) calls exactly this method, so naive delegation makes
-the optimisation crash on real submissions while passing against mock objects
-that auto-create any attribute.
-
-The fix is to let the wrapper's own class members take precedence over proxied
-data.  We test [[name in LazySubmission.__dict__]]: methods and class attributes
-defined on the wrapper are served from the wrapper, and only genuinely foreign
-names fall through to the submission.  This cannot shadow real submission data,
-because submission payload attributes ([[grade]], [[body]], \dots) never collide
-with the handful of method names we define here.
+The shell below establishes the stored state; each method follows in its own
+section.  We collect the methods in the [[LazySubmission methods]] bucket chunk
+so that source order can follow the pedagogical order above rather than Python's
+definition order.
 
 <<LazySubmission class>>=
 class LazySubmission:
@@ -3637,112 +3631,185 @@ class LazySubmission:
     object.__setattr__(self, '_original_get_submission', original_get_submission)
     object.__setattr__(self, '_last_refresh', datetime.now())
 
-  def _needs_refresh(self):
-    """Check if the wrapped submission needs refreshing."""
-    submission = object.__getattribute__(self, '_submission')
-    last_refresh = object.__getattribute__(self, '_last_refresh')
+  <<LazySubmission methods>>
 
-    # Never refresh final grades
-    if submission.grade in NOREFRESH_GRADES:
-      return False
-
-    # Check time-based staleness (5-minute TTL for non-final grades)
-    if datetime.now() - last_refresh > timedelta(minutes=5):
-      return True
-
-    return False
-
-  def would_need_refresh(self):
-    """
-    Check if submission would need refresh WITHOUT triggering it.
-
-    Used by pre-check phase to count stale submissions before deciding
-    whether to do bulk refresh.
-
-    Returns:
-        bool: True if submission would refresh on next access
-    """
-    return self._needs_refresh()
-
-  def ensure_attrs(self, attrs):
-    """Fill in any missing names in attrs on the wrapped submission as None.
-
-    Normalisation must not read mutable attributes through the wrapper:
-    probing presence with hasattr would route through __getattribute__ and
-    trigger a staleness refresh (a network call) for what should be a purely
-    local fill-in. We therefore operate on the wrapped submission directly,
-    leaving the lazy-refresh behaviour for genuine attribute reads.
-    """
-    submission = object.__getattribute__(self, '_submission')
-    for attr in attrs:
-      if not hasattr(submission, attr):
-        setattr(submission, attr, None)
-    return self
-
-  def _refresh(self):
-    """Refresh the wrapped submission from Canvas."""
-    assignment = object.__getattribute__(self, '_assignment')
-    submission = object.__getattribute__(self, '_submission')
-    includes = object.__getattribute__(self, '_includes')
-    original_get_submission = object.__getattribute__(self, '_original_get_submission')
-
-    # Call original method directly (bypasses decorator, no double-wrapping)
-    fresh_submission = original_get_submission(
-      assignment,
-      submission.user_id,
-      include=list(includes)
-    )
-
-    # Update internal state (cache automatically updated via reference)
-    object.__setattr__(self, '_submission', fresh_submission)
-    object.__setattr__(self, '_last_refresh', datetime.now())
-
-  def __getattribute__(self, name):
-    """
-    Intercept attribute access to trigger refresh when needed.
-
-    Logic:
-    1. Internal attributes (_*) and the wrapper's own members: access directly
-    2. Mutable attributes: check staleness, refresh if needed, then delegate
-    3. All other attributes: delegate to wrapped submission
-    """
-    # Serve internal state and the wrapper's own methods/class attributes from
-    # the wrapper itself; delegating them would proxy to the wrapped submission
-    # and raise AttributeError (see would_need_refresh / ensure_attrs).
-    if name.startswith('_') or name in LazySubmission.__dict__:
-      return object.__getattribute__(self, name)
-
-    # Check if this is a mutable attribute that might need refresh
-    if name in LazySubmission.MUTABLE_ATTRS:
-      if object.__getattribute__(self, '_needs_refresh')():
-        object.__getattribute__(self, '_refresh')()
-
-    # Delegate to wrapped submission
-    submission = object.__getattribute__(self, '_submission')
-    return getattr(submission, name)
-
-  def __setattr__(self, name, value):
-    """
-    Intercept attribute setting to handle both wrapper and submission attrs.
-
-    Internal attributes (_*) are set on the wrapper.
-    All other attributes are set on the wrapped submission.
-    """
-    if name.startswith('_'):
-      object.__setattr__(self, name, value)
-    else:
-      submission = object.__getattribute__(self, '_submission')
-      setattr(submission, name, value)
-
+  <<pickle support for LazySubmission>>
 @
 
-\subsubsection{Surviving a refresh: serving [[assignment]] from [[_assignment]]}
+\paragraph{Deciding when to refresh}
 
-A subtle interaction lurks between [[__setattr__]] and [[_refresh]].  Callers
-attach the parent assignment to a submission so that downstream code can reach
-[[submission.assignment.course]]---the results command does this for every
-submission it summarises.  Because [[assignment]] is not a private name,
-[[__setattr__]] stores it on the \emph{wrapped} submission, not on the wrapper.
+A non-final grade can still change on Canvas, so we re-fetch it once it is older
+than a short time-to-live.  A \emph{final} grade never changes, so we skip the
+refresh entirely---this is the [[NOREFRESH_GRADES]] policy, and it is what keeps
+a fully graded course from re-fetching every submission on access.
+
+<<LazySubmission methods>>=
+def _needs_refresh(self):
+  """Check if the wrapped submission needs refreshing."""
+  submission = object.__getattribute__(self, '_submission')
+  last_refresh = object.__getattribute__(self, '_last_refresh')
+
+  # Never refresh final grades
+  if submission.grade in NOREFRESH_GRADES:
+    return False
+
+  # Check time-based staleness (5-minute TTL for non-final grades)
+  if datetime.now() - last_refresh > timedelta(minutes=5):
+    return True
+
+  return False
+@
+
+The pre-check that decides whether a \emph{bulk} refresh is worthwhile
+(\cref{sec:bulk-refresh}) must count stale submissions without refreshing any of
+them.  [[_needs_refresh]] already answers that question with no side effects, so
+[[would_need_refresh]] merely exposes it under a public name that reads clearly
+at the call site.
+
+<<LazySubmission methods>>=
+def would_need_refresh(self):
+  """
+  Check if submission would need refresh WITHOUT triggering it.
+
+  Used by pre-check phase to count stale submissions before deciding
+  whether to do bulk refresh.
+
+  Returns:
+      bool: True if submission would refresh on next access
+  """
+  return self._needs_refresh()
+@
+
+\paragraph{Filling in attributes without a refresh}
+
+The CLI normalises submissions in bulk so that later code can read a fixed set
+of attributes without scattered [[getattr]] fallbacks.  That fill-in must not
+itself trigger refreshes: probing presence through the wrapper would route a
+mutable name through [[__getattribute__]] and fire a network call for what is
+meant to be a purely local touch-up.  We therefore reach past the wrapper with
+[[object.__getattribute__]] and operate on the wrapped submission directly.
+
+<<LazySubmission methods>>=
+def ensure_attrs(self, attrs):
+  """Fill in any missing names in attrs on the wrapped submission as None.
+
+  Normalisation must not read mutable attributes through the wrapper:
+  probing presence with hasattr would route through __getattribute__ and
+  trigger a staleness refresh (a network call) for what should be a purely
+  local fill-in. We therefore operate on the wrapped submission directly,
+  leaving the lazy-refresh behaviour for genuine attribute reads.
+  """
+  submission = object.__getattribute__(self, '_submission')
+  for attr in attrs:
+    if not hasattr(submission, attr):
+      setattr(submission, attr, None)
+  return self
+@
+
+\paragraph{Performing the refresh}
+
+Refreshing re-fetches the submission for the same user, assignment, and
+[[include]] set.  We call the \emph{unwrapped} [[get_submission]] captured at
+construction rather than the decorated one, so the refresh does not recurse back
+through the cache and double-wrap the result.  Rebinding [[_submission]] updates
+every holder of this wrapper at once, because they all share the one wrapper
+object---which is exactly why the cache need not be touched separately.
+
+<<LazySubmission methods>>=
+def _refresh(self):
+  """Refresh the wrapped submission from Canvas."""
+  assignment = object.__getattribute__(self, '_assignment')
+  submission = object.__getattribute__(self, '_submission')
+  includes = object.__getattribute__(self, '_includes')
+  original_get_submission = object.__getattribute__(self, '_original_get_submission')
+
+  # Call original method directly (bypasses decorator, no double-wrapping)
+  fresh_submission = original_get_submission(
+    assignment,
+    submission.user_id,
+    include=list(includes)
+  )
+
+  # Update internal state (cache automatically updated via reference)
+  object.__setattr__(self, '_submission', fresh_submission)
+  object.__setattr__(self, '_last_refresh', datetime.now())
+@
+
+\paragraph{Intercepting reads}
+
+A transparent proxy has two kinds of attributes to serve, and conflating them
+is a subtle trap.  Most names---[[grade]], [[user_id]], [[body]]---belong to the
+wrapped submission and should be delegated.  But the wrapper also has its own
+behavioural API: the staleness probe [[would_need_refresh]] and the
+normalisation hook [[ensure_attrs]].  If [[__getattribute__]] delegates
+\emph{everything} that is not a dunder or underscore-private name, then
+[[lazy.would_need_refresh]] is looked up on the wrapped submission---which has no
+such method---and raises [[AttributeError]].  The bulk-refresh pre-check
+(\cref{sec:bulk-refresh}) calls exactly this method, so naive delegation would
+crash the optimisation on real submissions while passing against mock objects
+that auto-create any attribute.
+
+The fix is to let the wrapper's own class members take precedence over proxied
+data.  We test [[name in LazySubmission.__dict__]]: methods and class attributes
+defined on the wrapper are served from the wrapper, and only genuinely foreign
+names fall through to the submission.  This cannot shadow real submission data,
+because submission payload attributes ([[grade]], [[body]], \dots) never collide
+with the handful of method names we define here.  Once delegation is reached, a
+mutable name first gets a staleness check, so reads always see fresh-enough data.
+
+<<LazySubmission methods>>=
+def __getattribute__(self, name):
+  """
+  Intercept attribute access to trigger refresh when needed.
+
+  Logic:
+  1. Internal attributes (_*) and the wrapper's own members: access directly
+  2. Mutable attributes: check staleness, refresh if needed, then delegate
+  3. All other attributes: delegate to wrapped submission
+  """
+  # Serve internal state and the wrapper's own methods/class attributes from
+  # the wrapper itself; delegating them would proxy to the wrapped submission
+  # and raise AttributeError (see would_need_refresh / ensure_attrs).
+  if name.startswith('_') or name in LazySubmission.__dict__:
+    return object.__getattribute__(self, name)
+
+  # Check if this is a mutable attribute that might need refresh
+  if name in LazySubmission.MUTABLE_ATTRS:
+    if object.__getattribute__(self, '_needs_refresh')():
+      object.__getattribute__(self, '_refresh')()
+
+  # Delegate to wrapped submission
+  submission = object.__getattribute__(self, '_submission')
+  return getattr(submission, name)
+@
+
+\paragraph{Intercepting writes}
+
+Writes mirror reads: internal state---the underscore-private names---stays on
+the wrapper, while every other name is set on the wrapped submission so callers
+can annotate it.  The most important such annotation is [[assignment]], whose
+fate after a refresh we turn to next.
+
+<<LazySubmission methods>>=
+def __setattr__(self, name, value):
+  """
+  Intercept attribute setting to handle both wrapper and submission attrs.
+
+  Internal attributes (_*) are set on the wrapper.
+  All other attributes are set on the wrapped submission.
+  """
+  if name.startswith('_'):
+    object.__setattr__(self, name, value)
+  else:
+    submission = object.__getattribute__(self, '_submission')
+    setattr(submission, name, value)
+@
+
+\paragraph{Surviving a refresh: serving [[assignment]] from [[_assignment]]}
+
+A subtle interaction lurks between [[__setattr__]] and [[_refresh]].  As just
+noted, a caller-set [[assignment]] lands on the \emph{wrapped} submission, since
+[[assignment]] is not a private name.
 
 Now suppose a later read touches a mutable attribute such as
 [[submission_history]].  That access triggers [[_refresh]], which fetches a
@@ -3766,33 +3833,39 @@ intact [[assignment]] on the wrapped submission is still returned directly, and
 only a missing one reaches us here.  We guard on [[_assignment]] being present
 so that a wrapper genuinely lacking an assignment still raises the ordinary
 [[AttributeError]] rather than masking it with [[None]].
-<<LazySubmission class>>=
-  def __getattr__(self, name):
-    """Fallback for attributes the wrapped submission no longer carries.
 
-    A refresh swaps in a freshly fetched submission that lacks any attribute a
-    caller set on the previous instance---notably ``assignment``.  The wrapper
-    keeps the assignment it was fetched from in ``_assignment`` (with its
-    ``course``), so serve that as the canonical fallback.
-    """
-    if name == "assignment":
-      assignment = object.__getattribute__(self, "_assignment")
-      if assignment is not None:
-        return assignment
-    submission = object.__getattribute__(self, '_submission')
-    return getattr(submission, name)
+<<LazySubmission methods>>=
+def __getattr__(self, name):
+  """Fallback for attributes the wrapped submission no longer carries.
 
-  def __repr__(self):
-    """Delegate repr to wrapped submission."""
-    submission = object.__getattribute__(self, '_submission')
-    return repr(submission)
+  A refresh swaps in a freshly fetched submission that lacks any attribute a
+  caller set on the previous instance---notably ``assignment``.  The wrapper
+  keeps the assignment it was fetched from in ``_assignment`` (with its
+  ``course``), so serve that as the canonical fallback.
+  """
+  if name == "assignment":
+    assignment = object.__getattribute__(self, "_assignment")
+    if assignment is not None:
+      return assignment
+  submission = object.__getattribute__(self, '_submission')
+  return getattr(submission, name)
+@
 
-  def __str__(self):
-    """Delegate str to wrapped submission."""
-    submission = object.__getattribute__(self, '_submission')
-    return str(submission)
+\paragraph{String representations}
 
-  <<pickle support for LazySubmission>>
+Both string hooks delegate to the wrapped submission so that a wrapper is
+indistinguishable from the object it proxies in logs and error messages.
+
+<<LazySubmission methods>>=
+def __repr__(self):
+  """Delegate repr to wrapped submission."""
+  submission = object.__getattribute__(self, '_submission')
+  return repr(submission)
+
+def __str__(self):
+  """Delegate str to wrapped submission."""
+  submission = object.__getattribute__(self, '_submission')
+  return str(submission)
 @
 
 \subsubsection{Pickle support for cache persistence}

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -3680,6 +3680,41 @@ def would_need_refresh(self):
   return self._needs_refresh()
 @
 
+Let us verify the policy with a minimal stand-in submission whose last refresh
+we can age at will.  A non-final grade older than the TTL must report that it
+would refresh, whereas a final grade never does---even when stale.
+
+<<test functions>>=
+class TestLazySubmissionStaleness:
+    """_needs_refresh implements the time-and-grade refresh policy."""
+
+    class StandInSubmission:
+        """A submission carrying only the attributes the policy reads."""
+
+        def __init__(self, grade):
+            self.grade = grade
+            self.user_id = 1
+
+    def wrap(self, *, grade, age_minutes):
+        """Wrap a stand-in submission whose last refresh is age_minutes old."""
+        lazy = LazySubmission(
+            self.StandInSubmission(grade), MagicMock(), set(), MagicMock())
+        object.__setattr__(
+            lazy, "_last_refresh",
+            datetime.now() - timedelta(minutes=age_minutes))
+        return lazy
+
+    def test_would_need_refresh_detects_staleness(self):
+        """A stale, non-final submission reports it would refresh."""
+        lazy = self.wrap(grade="F", age_minutes=10)
+        assert lazy.would_need_refresh() is True
+
+    def test_final_grade_never_needs_refresh(self):
+        """Final grades are never stale, even when old."""
+        lazy = self.wrap(grade="P", age_minutes=10)
+        assert lazy.would_need_refresh() is False
+@
+
 \paragraph{Filling in attributes without a refresh}
 
 The CLI normalises submissions in bulk so that later code can read a fixed set
@@ -3704,6 +3739,44 @@ def ensure_attrs(self, attrs):
     if not hasattr(submission, attr):
       setattr(submission, attr, None)
   return self
+@
+
+We verify that [[ensure_attrs]] fills in absent fields yet never calls the
+refresh function, even on a submission old enough to be stale---the whole point
+of reaching past the wrapper.
+
+<<test functions>>=
+class TestLazySubmissionNormalization:
+    """ensure_attrs fills missing fields without triggering a refresh."""
+
+    class StandInSubmission:
+        """A submission carrying only a couple of real attributes."""
+
+        def __init__(self, grade):
+            self.grade = grade
+            self.user_id = 1
+
+    def test_ensure_attrs_does_not_refresh_stale_submission(self):
+        """Normalising a stale wrapper must not issue a refresh call."""
+        refresh = MagicMock()
+        lazy = LazySubmission(
+            self.StandInSubmission("F"), MagicMock(), set(), refresh)
+        object.__setattr__(
+            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
+
+        lazy.ensure_attrs(["grade", "missing_field"])
+
+        refresh.assert_not_called()
+
+    def test_ensure_attrs_fills_missing_fields(self):
+        """Absent fields become None; existing fields are untouched."""
+        lazy = LazySubmission(
+            self.StandInSubmission("F"), MagicMock(), set(), MagicMock())
+
+        lazy.ensure_attrs(["grade", "missing_field"])
+
+        assert lazy.missing_field is None
+        assert lazy.grade == "F"
 @
 
 \paragraph{Performing the refresh}
@@ -3783,6 +3856,43 @@ def __getattribute__(self, name):
   return getattr(submission, name)
 @
 
+Let us verify the two halves of this split.  We wrap a stand-in that
+deliberately lacks a [[would_need_refresh]] method: if the wrapper delegated the
+call, the stand-in would raise [[AttributeError]]; instead the wrapper answers
+from its own logic.  A genuine payload attribute, by contrast, must still come
+from the wrapped submission.
+
+<<test functions>>=
+class TestLazySubmissionDelegation:
+    """The wrapper's own methods are served locally; payload is delegated."""
+
+    class StandInSubmission:
+        """A submission without any wrapper methods of its own."""
+
+        def __init__(self, grade):
+            self.grade = grade
+            self.user_id = 1
+
+    def wrap(self, *, grade, age_minutes):
+        """Wrap a stand-in submission whose last refresh is age_minutes old."""
+        lazy = LazySubmission(
+            self.StandInSubmission(grade), MagicMock(), set(), MagicMock())
+        object.__setattr__(
+            lazy, "_last_refresh",
+            datetime.now() - timedelta(minutes=age_minutes))
+        return lazy
+
+    def test_would_need_refresh_is_reachable(self):
+        """Calling would_need_refresh() returns a bool, not AttributeError."""
+        lazy = self.wrap(grade="F", age_minutes=0)
+        assert lazy.would_need_refresh() is False
+
+    def test_payload_attribute_still_delegates(self):
+        """Submission payload attributes still come from the submission."""
+        lazy = self.wrap(grade="F", age_minutes=0)
+        assert lazy.user_id == 1
+@
+
 \paragraph{Intercepting writes}
 
 Writes mirror reads: internal state---the underscore-private names---stays on
@@ -3849,6 +3959,57 @@ def __getattr__(self, name):
       return assignment
   submission = object.__getattribute__(self, '_submission')
   return getattr(submission, name)
+@
+
+Now let's verify the [[assignment]] fallback.  A caller-set [[assignment]] lives
+on the wrapped submission, so a refresh---which rebinds [[_submission]] to a
+freshly fetched object---would otherwise discard it.  We check both that the
+wrapper serves [[assignment]] from [[_assignment]] when the wrapped submission
+lacks it, and that the attribute therefore survives an actual refresh.
+
+<<test functions>>=
+class TestLazySubmissionAssignmentSurvivesRefresh:
+    """`.assignment` falls back to the stored assignment after a refresh."""
+
+    class StandInSubmission:
+        """A submission as Canvas returns it: no caller-set `.assignment`."""
+
+        def __init__(self, grade="F"):
+            self.grade = grade
+            self.user_id = 1
+            self.submission_history = ()
+
+    def test_assignment_served_from_wrapper_when_missing(self):
+        """A wrapped submission without `.assignment` falls back to
+        `_assignment`."""
+        sentinel_assignment = object()
+        lazy = LazySubmission(
+            self.StandInSubmission(), sentinel_assignment, set(), MagicMock())
+
+        assert lazy.assignment is sentinel_assignment
+
+    def test_assignment_survives_a_refresh(self):
+        """A refresh swaps the wrapped submission yet `.assignment` persists."""
+        sentinel_assignment = object()
+        fresh = self.StandInSubmission()
+        # The refresh fetches a new submission that lacks `.assignment`.
+        original_get_submission = MagicMock(return_value=fresh)
+
+        lazy = LazySubmission(
+            self.StandInSubmission(), sentinel_assignment,
+            {"submission_history"}, original_get_submission)
+        # A caller attaches the assignment to the wrapped submission, ...
+        lazy.assignment = sentinel_assignment
+        # ... but the wrapper is stale, so the next mutable read refreshes.
+        object.__setattr__(
+            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
+
+        # Touching a mutable attribute swaps in `fresh`, dropping `.assignment`.
+        lazy.submission_history
+
+        original_get_submission.assert_called_once()
+        assert not hasattr(fresh, "assignment")
+        assert lazy.assignment is sentinel_assignment
 @
 
 \paragraph{String representations}
@@ -4017,143 +4178,6 @@ def __setstate__(self, state):
 This class is used by the caching decorator below.
 <<functions>>=
 <<LazySubmission class>>
-@
-
-Let us verify that the wrapper's own methods stay reachable rather than being
-proxied to the wrapped submission.  We wrap a minimal stand-in submission that
-deliberately lacks a [[would_need_refresh]] method: if the wrapper delegated the
-call, the stand-in would raise [[AttributeError]]; instead the wrapper answers
-from its own staleness logic.
-
-<<test functions>>=
-class TestLazySubmissionMethodAccess:
-    """The wrapper's own methods must not be proxied to the submission."""
-
-    class StandInSubmission:
-        """A submission without any wrapper methods of its own."""
-
-        def __init__(self, grade):
-            self.grade = grade
-            self.user_id = 1
-
-    def wrap(self, *, grade, age_minutes):
-        """Wrap a stand-in submission whose last refresh is age_minutes old."""
-        lazy = LazySubmission(
-            self.StandInSubmission(grade), MagicMock(), set(), MagicMock())
-        object.__setattr__(
-            lazy, "_last_refresh",
-            datetime.now() - timedelta(minutes=age_minutes))
-        return lazy
-
-    def test_would_need_refresh_is_reachable(self):
-        """Calling would_need_refresh() returns a bool, not AttributeError."""
-        lazy = self.wrap(grade="F", age_minutes=0)
-        assert lazy.would_need_refresh() is False
-
-    def test_would_need_refresh_detects_staleness(self):
-        """A stale, non-final submission reports it would refresh."""
-        lazy = self.wrap(grade="F", age_minutes=10)
-        assert lazy.would_need_refresh() is True
-
-    def test_final_grade_never_needs_refresh(self):
-        """Final grades are never stale, even when old."""
-        lazy = self.wrap(grade="P", age_minutes=10)
-        assert lazy.would_need_refresh() is False
-
-    def test_payload_attribute_still_delegates(self):
-        """Submission payload attributes still come from the submission."""
-        lazy = self.wrap(grade="F", age_minutes=0)
-        assert lazy.user_id == 1
-@
-
-The [[ensure_attrs]] hook is what lets the CLI normalise submissions in bulk
-without paying for a refresh per submission.  We verify that it fills in absent
-fields yet never calls the refresh function, even on a submission old enough to
-be stale.
-
-<<test functions>>=
-class TestLazySubmissionNormalization:
-    """ensure_attrs fills missing fields without triggering a refresh."""
-
-    class StandInSubmission:
-        """A submission carrying only a couple of real attributes."""
-
-        def __init__(self, grade):
-            self.grade = grade
-            self.user_id = 1
-
-    def test_ensure_attrs_does_not_refresh_stale_submission(self):
-        """Normalising a stale wrapper must not issue a refresh call."""
-        refresh = MagicMock()
-        lazy = LazySubmission(
-            self.StandInSubmission("F"), MagicMock(), set(), refresh)
-        object.__setattr__(
-            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
-
-        lazy.ensure_attrs(["grade", "missing_field"])
-
-        refresh.assert_not_called()
-
-    def test_ensure_attrs_fills_missing_fields(self):
-        """Absent fields become None; existing fields are untouched."""
-        lazy = LazySubmission(
-            self.StandInSubmission("F"), MagicMock(), set(), MagicMock())
-
-        lazy.ensure_attrs(["grade", "missing_field"])
-
-        assert lazy.missing_field is None
-        assert lazy.grade == "F"
-@
-
-Now let's verify the [[assignment]] fallback.  A caller-set [[assignment]] lives
-on the wrapped submission, so a refresh---which rebinds [[_submission]] to a
-freshly fetched object---would otherwise discard it.  We check both that the
-wrapper serves [[assignment]] from [[_assignment]] when the wrapped submission
-lacks it, and that the attribute therefore survives an actual refresh.
-
-<<test functions>>=
-class TestLazySubmissionAssignmentSurvivesRefresh:
-    """`.assignment` falls back to the stored assignment after a refresh."""
-
-    class StandInSubmission:
-        """A submission as Canvas returns it: no caller-set `.assignment`."""
-
-        def __init__(self, grade="F"):
-            self.grade = grade
-            self.user_id = 1
-            self.submission_history = ()
-
-    def test_assignment_served_from_wrapper_when_missing(self):
-        """A wrapped submission without `.assignment` falls back to
-        `_assignment`."""
-        sentinel_assignment = object()
-        lazy = LazySubmission(
-            self.StandInSubmission(), sentinel_assignment, set(), MagicMock())
-
-        assert lazy.assignment is sentinel_assignment
-
-    def test_assignment_survives_a_refresh(self):
-        """A refresh swaps the wrapped submission yet `.assignment` persists."""
-        sentinel_assignment = object()
-        fresh = self.StandInSubmission()
-        # The refresh fetches a new submission that lacks `.assignment`.
-        original_get_submission = MagicMock(return_value=fresh)
-
-        lazy = LazySubmission(
-            self.StandInSubmission(), sentinel_assignment,
-            {"submission_history"}, original_get_submission)
-        # A caller attaches the assignment to the wrapped submission, ...
-        lazy.assignment = sentinel_assignment
-        # ... but the wrapper is stale, so the next mutable read refreshes.
-        object.__setattr__(
-            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
-
-        # Touching a mutable attribute swaps in `fresh`, dropping `.assignment`.
-        lazy.submission_history
-
-        original_get_submission.assert_called_once()
-        assert not hasattr(fresh, "assignment")
-        assert lazy.assignment is sentinel_assignment
 @
 
 \subsubsection{Threshold-based bulk refresh optimization}

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -3734,8 +3734,51 @@ class LazySubmission:
       submission = object.__getattribute__(self, '_submission')
       setattr(submission, name, value)
 
+@
+
+\subsubsection{Surviving a refresh: serving [[assignment]] from [[_assignment]]}
+
+A subtle interaction lurks between [[__setattr__]] and [[_refresh]].  Callers
+attach the parent assignment to a submission so that downstream code can reach
+[[submission.assignment.course]]---the results command does this for every
+submission it summarises.  Because [[assignment]] is not a private name,
+[[__setattr__]] stores it on the \emph{wrapped} submission, not on the wrapper.
+
+Now suppose a later read touches a mutable attribute such as
+[[submission_history]].  That access triggers [[_refresh]], which fetches a
+\emph{new} submission from Canvas and rebinds [[_submission]] to it.  The
+freshly fetched object never had [[assignment]] assigned, so the caller's
+attribute silently vanishes---and the next read of [[submission.assignment]]
+raises [[AttributeError]].
+
+We cannot recover the lost value from [[assignment_id]] alone: downstream code
+needs the assignment's [[course]] object, and re-fetching by id would neither
+restore [[course]] nor have a [[Canvas]] handle to query.  Fortunately the
+wrapper already retains exactly what we need.  [[_assignment]] is the
+[[Assignment]] the submission was fetched from---it carries [[course]] and is
+untouched by refreshes.  So when a delegated lookup of [[assignment]] fails, we
+fall back to [[_assignment]] as the canonical source.
+
+Python only calls [[__getattr__]] after normal lookup (including
+[[__getattribute__]]'s delegation to the wrapped submission) has already failed
+with [[AttributeError]].  That makes it the precise place for the fallback: an
+intact [[assignment]] on the wrapped submission is still returned directly, and
+only a missing one reaches us here.  We guard on [[_assignment]] being present
+so that a wrapper genuinely lacking an assignment still raises the ordinary
+[[AttributeError]] rather than masking it with [[None]].
+<<LazySubmission class>>=
   def __getattr__(self, name):
-    """Fallback for attributes not found on wrapper (delegates to submission)."""
+    """Fallback for attributes the wrapped submission no longer carries.
+
+    A refresh swaps in a freshly fetched submission that lacks any attribute a
+    caller set on the previous instance---notably ``assignment``.  The wrapper
+    keeps the assignment it was fetched from in ``_assignment`` (with its
+    ``course``), so serve that as the canonical fallback.
+    """
+    if name == "assignment":
+      assignment = object.__getattribute__(self, "_assignment")
+      if assignment is not None:
+        return assignment
     submission = object.__getattribute__(self, '_submission')
     return getattr(submission, name)
 
@@ -3987,6 +4030,57 @@ class TestLazySubmissionNormalization:
 
         assert lazy.missing_field is None
         assert lazy.grade == "F"
+@
+
+Now let's verify the [[assignment]] fallback.  A caller-set [[assignment]] lives
+on the wrapped submission, so a refresh---which rebinds [[_submission]] to a
+freshly fetched object---would otherwise discard it.  We check both that the
+wrapper serves [[assignment]] from [[_assignment]] when the wrapped submission
+lacks it, and that the attribute therefore survives an actual refresh.
+
+<<test functions>>=
+class TestLazySubmissionAssignmentSurvivesRefresh:
+    """`.assignment` falls back to the stored assignment after a refresh."""
+
+    class StandInSubmission:
+        """A submission as Canvas returns it: no caller-set `.assignment`."""
+
+        def __init__(self, grade="F"):
+            self.grade = grade
+            self.user_id = 1
+            self.submission_history = ()
+
+    def test_assignment_served_from_wrapper_when_missing(self):
+        """A wrapped submission without `.assignment` falls back to
+        `_assignment`."""
+        sentinel_assignment = object()
+        lazy = LazySubmission(
+            self.StandInSubmission(), sentinel_assignment, set(), MagicMock())
+
+        assert lazy.assignment is sentinel_assignment
+
+    def test_assignment_survives_a_refresh(self):
+        """A refresh swaps the wrapped submission yet `.assignment` persists."""
+        sentinel_assignment = object()
+        fresh = self.StandInSubmission()
+        # The refresh fetches a new submission that lacks `.assignment`.
+        original_get_submission = MagicMock(return_value=fresh)
+
+        lazy = LazySubmission(
+            self.StandInSubmission(), sentinel_assignment,
+            {"submission_history"}, original_get_submission)
+        # A caller attaches the assignment to the wrapped submission, ...
+        lazy.assignment = sentinel_assignment
+        # ... but the wrapper is stale, so the next mutable read refreshes.
+        object.__setattr__(
+            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
+
+        # Touching a mutable attribute swaps in `fresh`, dropping `.assignment`.
+        lazy.submission_history
+
+        original_get_submission.assert_called_once()
+        assert not hasattr(fresh, "assignment")
+        assert lazy.assignment is sentinel_assignment
 @
 
 \subsubsection{Threshold-based bulk refresh optimization}


### PR DESCRIPTION
- **Serve LazySubmission.assignment from stored _assignment**
- **Decompose LazySubmission into per-method sections**
- **Distribute LazySubmission tests beside their methods**
