### PR TITLE
Improve caching system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -804,6 +804,16 @@ def example_command(config, canvas, args):
 - Raise `canvaslms.cli.EmptyListError` when no results match filters
 - Main CLI catches this and exits with code 1 (suppressed if `-q/--quiet`)
 
+### Cache Schema Versioning
+
+The persisted Canvas cache is stamped with `CACHE_SCHEMA_VERSION` (defined in
+`src/canvaslms/cli/cache.nw`). **Bump this constant whenever the layout of
+cached objects changes**: adding or removing a `CacheGetMethods` wrap,
+renaming cache attributes, or changing the shape of cache entries (e.g. the
+`LazySubmission` wrapper). A version mismatch discards the cache (one full
+refetch on the next run); a forgotten bump crashes on users' existing caches.
+When in doubt, bump. Do not write lazy migration shims for old cache layouts.
+
 ## Output Conventions
 
 - Default: tab-separated values (TSV) for Unix pipeline compatibility

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -366,10 +366,17 @@ To save the Canvas object, we:
 \begin{enumerate}
 \item Wrap the object in a version envelope and pickle it to bytes.
 \item Encrypt the bytes using Fernet (authenticated encryption).
-\item Write the encrypted bytes to the cache file.
+\item Write the encrypted bytes atomically to the cache file.
 \end{enumerate}
 
 If the cache directory doesn't exist, we create it first.
+
+The cache is optional, so a failed save must not break the command.
+But it must not be invisible either: if saving fails persistently (one
+unpicklable object in the graph is enough), the cache silently stops
+updating and every future run pays full API cost---a failure mode that is
+undiagnosable without a log message.
+We therefore log a warning and continue.
 <<functions>>=
 def save_canvas_cache(canvas, token, hostname):
   """Saves the Canvas object to encrypted cache"""
@@ -397,18 +404,48 @@ def save_canvas_cache(canvas, token, hostname):
     cache_path = get_cache_path(hostname)
     <<create cache directory if needed>>
     write_start = time.perf_counter()
-    with open(cache_path, "wb") as f:
-      f.write(encrypted)
+    <<write [[encrypted]] atomically to [[cache_path]]>>
     write_elapsed = time.perf_counter() - write_start
 
     save_elapsed = time.perf_counter() - save_start
     logger.info(f"Canvas cache save: {save_elapsed:.2f}s total "
                  f"(pickle: {pickle_elapsed:.2f}s/{pickle_size/1024:.1f}KB, "
                  f"encrypt: {encrypt_elapsed:.2f}s, write: {write_elapsed:.2f}s)")
-  except Exception:
-    # If saving fails, silently continue
-    # (cache is optional, don't break the command)
+  except Exception as err:
+    logger.warning(f"Canvas cache save failed ({err}); "
+                   f"continuing without saving the cache")
+@
+
+Writing the file in place would mean that a crash or kill mid-write leaves
+a truncated file; Fernet's authentication then rejects it on the next load,
+silently costing the user the whole cache.
+Instead we write to a temporary file in the same directory and
+[[os.replace]] it over the cache path, which is atomic on POSIX: the cache
+file always holds either the old complete bytes or the new complete bytes.
+
+The temporary name includes the process ID so that two concurrent
+[[canvaslms]] invocations don't interleave writes into the same temporary
+file; with distinct names, the last completed [[os.replace]] wins and both
+files are complete.
+
+We create the temporary file with mode [[0o600]]: the content is encrypted,
+but there is no reason to let other users read it at all.
+[[os.replace]] preserves the mode, so the cache file inherits it.
+If anything fails after the temporary file was created, we remove it on a
+best-effort basis before re-raising to the warning handler above.
+<<write [[encrypted]] atomically to [[cache_path]]>>=
+tmp_path = f"{cache_path}.{os.getpid()}.tmp"
+fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+try:
+  with os.fdopen(fd, "wb") as f:
+    f.write(encrypted)
+  os.replace(tmp_path, cache_path)
+except BaseException:
+  try:
+    os.remove(tmp_path)
+  except OSError:
     pass
+  raise
 @
 
 If the cache directory doesn't exist, we must create it.
@@ -436,6 +473,13 @@ The decryption can fail for several reasons:
 \item The token has changed (different key).
 \end{itemize}
 In all these cases, the correct behavior is to create a fresh Canvas object.
+
+We distinguish the failure modes when logging.
+A missing file is the normal first-run case and stays quiet.
+A decryption failure usually means the token changed and is expected
+behavior, so we log it at INFO.
+Anything else is unexpected; we log it at WARNING, because an undiagnosed
+load failure silently degrades every run to full API cost.
 <<functions>>=
 def load_canvas_cache(token, hostname):
   """Loads the Canvas object from encrypted cache, returns None if unavailable"""
@@ -470,8 +514,14 @@ def load_canvas_cache(token, hostname):
                  f"decrypt: {decrypt_elapsed:.2f}s, unpickle: {unpickle_elapsed:.2f}s)")
 
     return payload["canvas"]
-  except (FileNotFoundError, InvalidToken, pickle.UnpicklingError, Exception):
-    # Cache doesn't exist or is invalid, return None
+  except FileNotFoundError:
+    return None
+  except InvalidToken:
+    logger.info("Canvas cache exists but cannot be decrypted "
+                "(token changed?); starting fresh")
+    return None
+  except Exception as err:
+    logger.warning(f"Canvas cache load failed ({err}); starting fresh")
     return None
 @
 
@@ -531,6 +581,38 @@ def test_cache_discards_wrong_version(tmp_cache_path):
       Fernet(key).encrypt(pickle.dumps(envelope)))
 
   assert cache.load_canvas_cache("token", "https://host") is None
+@
+
+Let's also verify the failure and atomicity behavior of saving: a failing
+save must leave an existing cache file untouched and emit a warning, a
+missing cache file must load quietly as [[None]], and the saved file must
+not be readable by other users.
+
+<<test functions>>=
+def test_failed_save_keeps_old_cache_and_warns(
+    tmp_cache_path, monkeypatch, caplog):
+  """A failing save should leave the old cache intact and log a warning."""
+  cache.save_canvas_cache({"old": "cache"}, "token", "https://host")
+  old_bytes = tmp_cache_path.read_bytes()
+
+  def broken_dumps(obj):
+    raise RuntimeError("unpicklable object in graph")
+  monkeypatch.setattr(cache.pickle, "dumps", broken_dumps)
+
+  cache.save_canvas_cache({"new": "cache"}, "token", "https://host")
+
+  assert tmp_cache_path.read_bytes() == old_bytes
+  assert "cache save failed" in caplog.text
+
+def test_load_missing_cache_returns_none(tmp_cache_path):
+  """Loading without a cache file should quietly return None."""
+  assert cache.load_canvas_cache("token", "https://host") is None
+
+def test_saved_cache_is_user_only(tmp_cache_path):
+  """The cache file should be created with mode 0600."""
+  cache.save_canvas_cache({"fake": "canvas"}, "token", "https://host")
+
+  assert tmp_cache_path.stat().st_mode & 0o777 == 0o600
 @
 
 

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -72,6 +72,7 @@ from canvaslms.hacks.canvasapi import (
 logger = logging.getLogger(__name__)
 dirs = appdirs.AppDirs("canvaslms", "dbosk@kth.se")
 
+<<constants>>
 <<classes and exceptions>>
 <<functions>>
 @
@@ -332,11 +333,38 @@ def get_cache_path(hostname):
 @
 
 
+\subsection{Versioning the cache format}
+
+A pickled cache outlives the code that wrote it.
+The decorators in [[hacks/canvasapi.nw]] inject cache attributes in wrapped
+constructors, but unpickling never runs [[__init__]]: an object pickled
+before its class gained a wrap lacks that wrap's attributes, and the first
+wrapped call crashes with [[AttributeError]].
+The same applies when the shape of cache entries changes (as when plain
+submission tuples became [[LazySubmission]] wrappers).
+We used to patch over such mismatches with lazy migration shims, but every
+layout change risks a new variant and the shims accumulate.
+
+Instead, we stamp every cache file with a schema version and discard the
+whole cache on mismatch.
+The cost is one full refetch after an upgrade that changes the cached
+layout; the benefit is that no run ever sees objects shaped by older code.
+
+\textbf{Maintainers: bump [[CACHE_SCHEMA_VERSION]] whenever the layout of
+cached objects changes.}
+That includes adding or removing a [[CacheGetMethods]] wrap, renaming cache
+attributes, and changing the shape of cache entries.
+A mismatch costs one refetch; a forgotten bump costs crashes on users'
+existing caches---when in doubt, bump.
+<<constants>>=
+CACHE_SCHEMA_VERSION = 1
+@
+
 \subsection{Saving the Canvas object}
 
 To save the Canvas object, we:
 \begin{enumerate}
-\item Pickle the object to bytes.
+\item Wrap the object in a version envelope and pickle it to bytes.
 \item Encrypt the bytes using Fernet (authenticated encryption).
 \item Write the encrypted bytes to the cache file.
 \end{enumerate}
@@ -354,7 +382,10 @@ def save_canvas_cache(canvas, token, hostname):
 
     # Pickle and encrypt
     pickle_start = time.perf_counter()
-    pickled = pickle.dumps(canvas)
+    pickled = pickle.dumps({
+      "version": CACHE_SCHEMA_VERSION,
+      "canvas": canvas,
+    })
     pickle_elapsed = time.perf_counter() - pickle_start
     pickle_size = len(pickled)
 
@@ -392,17 +423,17 @@ To load the Canvas object, we:
 \begin{enumerate}
 \item Read the encrypted bytes from the cache file.
 \item Decrypt using the key derived from the token.
-\item Unpickle to reconstruct the Canvas object.
+\item Unpickle and check the version envelope.
 \end{enumerate}
 
-If any step fails (file not found, decryption fails, unpickling fails), we
-return [[None]] to indicate that a new Canvas object should be created.
+If any step fails (file not found, decryption fails, unpickling fails, or
+the schema version doesn't match), we return [[None]] to indicate that a
+new Canvas object should be created.
 
 The decryption can fail for several reasons:
 \begin{itemize}
 \item The cache file is corrupted.
 \item The token has changed (different key).
-\item The cache was created with a different version of the code.
 \end{itemize}
 In all these cases, the correct behavior is to create a fresh Canvas object.
 <<functions>>=
@@ -428,18 +459,78 @@ def load_canvas_cache(token, hostname):
     decrypt_elapsed = time.perf_counter() - decrypt_start
 
     unpickle_start = time.perf_counter()
-    canvas = pickle.loads(pickled)
+    payload = pickle.loads(pickled)
     unpickle_elapsed = time.perf_counter() - unpickle_start
+
+    <<discard [[payload]] on schema mismatch>>
 
     load_elapsed = time.perf_counter() - load_start
     logger.info(f"Canvas cache load: {load_elapsed:.2f}s total "
                  f"(read: {read_elapsed:.2f}s/{encrypted_size/1024:.1f}KB, "
                  f"decrypt: {decrypt_elapsed:.2f}s, unpickle: {unpickle_elapsed:.2f}s)")
 
-    return canvas
+    return payload["canvas"]
   except (FileNotFoundError, InvalidToken, pickle.UnpicklingError, Exception):
     # Cache doesn't exist or is invalid, return None
     return None
+@
+
+A cache written by an older canvaslms is a bare pickled [[Canvas]] object,
+not a dict, so the [[isinstance]] check rejects it just like a wrong
+version number.
+We log the discard at INFO level: the next run will be slow (full
+refetch), and the user deserves to know why.
+<<discard [[payload]] on schema mismatch>>=
+if (not isinstance(payload, dict)
+    or payload.get("version") != CACHE_SCHEMA_VERSION):
+  found = payload.get("version") if isinstance(payload, dict) else None
+  logger.info(f"Canvas cache schema changed (found: {found}, "
+              f"expected: {CACHE_SCHEMA_VERSION}); "
+              f"discarding cache and starting fresh")
+  return None
+@
+
+Let's verify the envelope: a round trip must return the cached object,
+while a bare (pre-envelope) payload and a wrong version number must both be
+discarded.
+
+<<test functions>>=
+@pytest.fixture
+def tmp_cache_path(monkeypatch, tmp_path):
+  """Redirect the cache file to a temporary path."""
+  path = tmp_path / "canvas_cache_test.enc"
+  monkeypatch.setattr(cache, "get_cache_path", lambda hostname: str(path))
+  return path
+
+def test_cache_round_trip(tmp_cache_path):
+  """Saving and loading should return the cached object."""
+  cache.save_canvas_cache({"fake": "canvas"}, "token", "https://host")
+
+  assert cache.load_canvas_cache("token", "https://host") == \
+      {"fake": "canvas"}
+
+def test_cache_discards_unversioned_payload(tmp_cache_path):
+  """A bare pickled object (pre-envelope cache) should be discarded."""
+  import pickle
+  from cryptography.fernet import Fernet
+
+  key = cache.derive_key("token", "https://host")
+  tmp_cache_path.write_bytes(
+      Fernet(key).encrypt(pickle.dumps(["bare canvas object"])))
+
+  assert cache.load_canvas_cache("token", "https://host") is None
+
+def test_cache_discards_wrong_version(tmp_cache_path):
+  """An envelope with a different schema version should be discarded."""
+  import pickle
+  from cryptography.fernet import Fernet
+
+  key = cache.derive_key("token", "https://host")
+  envelope = {"version": cache.CACHE_SCHEMA_VERSION - 1, "canvas": {}}
+  tmp_cache_path.write_bytes(
+      Fernet(key).encrypt(pickle.dumps(envelope)))
+
+  assert cache.load_canvas_cache("token", "https://host") is None
 @
 
 

--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -222,12 +222,29 @@ def load_configured_canvas(config, use_cache=True):
 
   hostname = normalize_hostname(hostname)
 
+  <<register attachment encryption key>>
+
   if use_cache:
     canvas = load_canvas_cache(token, hostname)
     if canvas:
       return canvas, hostname, token
 
   return create_canvas(hostname, token), hostname, token
+@
+
+The attachment cache (see [[hacks/attachment_cache.nw]]) encrypts cached
+submission files with the same token-derived key as the Canvas object
+cache.
+We register the key here because this loader is the single bootstrap that
+both the command-line interface and the package API pass through, and
+because the attachment module should handle a ready [[Fernet]] instance,
+never the token itself.
+The registration is unconditional: the attachment cache is independent of
+the Canvas object cache, so it keeps working under [[--no-cache]], just as
+it did before encryption.
+This costs one extra PBKDF2 derivation per invocation (about 0.1 seconds).
+<<register attachment encryption key>>=
+attachment_cache.set_fernet(Fernet(derive_key(token, hostname)))
 @
 
 <<test functions>>=

--- a/src/canvaslms/cli/cli.nw
+++ b/src/canvaslms/cli/cli.nw
@@ -461,16 +461,9 @@ The reason is that the cache state is monotonically improving: the decorators
 in [[hacks/canvasapi.nw]] only \emph{add} or \emph{refresh} entries---never
 corrupt or remove valid ones---so whatever new objects [[args.func]] managed
 to fetch before an error are still worth persisting.
-This matters in two cases in particular:
-\begin{itemize}
-\item Long-running queries that filter a large result set down to nothing
-  raise [[EmptyListError]] only after warming a substantial part of the
-  cache.
-\item [[purge_legacy_submission_entries]] in [[hacks/canvasapi.nw]] evicts
-  stale-shape entries lazily on every cache touch; without saving on the
-  error path, that cleanup would be discarded and the next run would
-  repeat all the legacy evictions.
-\end{itemize}
+This matters in particular for long-running queries that filter a large
+result set down to nothing: they raise [[EmptyListError]] only after warming
+a substantial part of the cache, and saving preserves that warm-up.
 
 We still skip saving when no Canvas object was used (e.g. the [[login]]
 command) or when the user explicitly passed [[--no-cache]].

--- a/src/canvaslms/cli/submissions.nw
+++ b/src/canvaslms/cli/submissions.nw
@@ -1711,8 +1711,10 @@ contents = convert_to_md(attachment, tmpdir)
 @
 
 We check if the attachment is already cached before downloading.
-If cached, we copy from the cache to avoid redundant network requests.
-Otherwise, we download the file and add it to the cache.
+The cache stores attachments encrypted, so there is no file to copy from;
+instead [[restore_cached_attachment]] decrypts the content straight into
+[[outfile]].
+If that reports a miss, we download the file and add it to the cache.
 
 This is particularly important for computing diffs between submission versions:
 if a student submits version N+1, we already have the attachments from versions
@@ -1720,13 +1722,8 @@ N, N-1, \ldots cached locally, so we only need to download version N+1.
 
 <<download [[attachment]] to [[outfile]] in [[tmpdir]]>>=
 outfile = tmpdir / attachment.filename
-cached_path = attachment_cache.get_cached_attachment(attachment.id)
 
-if cached_path:
-  # Use cached file - copy to temporary directory for processing
-  import shutil
-  shutil.copy(cached_path, outfile)
-else:
+if not attachment_cache.restore_cached_attachment(attachment.id, outfile):
   # Download and cache for future use
   attachment.download(outfile)
   attachment_cache.cache_attachment(attachment.id, outfile, {

--- a/src/canvaslms/cli/users.nw
+++ b/src/canvaslms/cli/users.nw
@@ -300,6 +300,11 @@ less the whole roster, one group at a time, on every run.
 Or we can ask Canvas to embed the members when we list the groups
 ([[include=["users"]]] in [[process_group_options]]), which piggybacks all
 memberships onto a single, already cached request.
+The two sources age differently: the embedded snapshot refreshes with the
+cached groups listing (every [[GROUP_CACHE_TTL_DAYS]] days, see
+[[hacks/canvasapi.nw]]), while the cached [[get_users()]] fallback refreshes
+every [[USER_CACHE_TTL_DAYS]] days; both cadences are acceptable for group
+membership.
 
 We prefer the embedded membership but keep [[get_users()]] as a fallback,
 because the embedded list is not always trustworthy: the listing endpoint

--- a/src/canvaslms/cli/users.nw
+++ b/src/canvaslms/cli/users.nw
@@ -258,10 +258,11 @@ def make_user_rows_w_groups(canvas, args, roles):
   includes a group column"""
 
   groups = process_group_options(canvas, args)
+  users_by_course = {}
 
   for group in groups:
     <<resolve [[group]] members in the owning [[course]]>>
-    users = filter_users([course], args.regex, roles)
+    <<look up role-filtered [[users]] of [[course]]>>
 
     for user in users:
       if user.id not in member_ids:
@@ -362,6 +363,20 @@ def test_group_member_ids_falls_back_without_embedding():
     assert users_module.group_member_ids(group) == {100}
 @
 
+Many groups typically belong to the same course---lab groups, for
+instance, partition the whole roster.
+The role-filtered roster is the same for all of them, so filtering it anew
+for every group would re-walk the entire cached user list (and re-log the
+cache traversal) once per group.
+We therefore filter each course's roster once and share the result across
+its groups.
+<<look up role-filtered [[users]] of [[course]]>>=
+if course.id not in users_by_course:
+  users_by_course[course.id] = list(
+    filter_users([course], args.regex, roles))
+users = users_by_course[course.id]
+@
+
 Now let's verify the grouped path still recognizes students even when the
 group membership objects only contain identifiers.
 This is the regression that previously made [[users -s -G]] return no users:
@@ -427,6 +442,66 @@ def test_make_user_rows_w_groups_filters_roles_in_course(monkeypatch):
     ]]
     group.get_users.assert_called_once_with()
     course.get_users.assert_called_once_with(include=["enrollments"])
+@
+
+Let's also verify that several groups in the same course share one
+filtered roster: the course users must be fetched and filtered once, not
+once per group.
+
+<<test functions>>=
+def test_make_user_rows_w_groups_filters_course_roster_once(monkeypatch):
+    """Groups in the same course should share one role-filtered roster"""
+    course = Mock()
+    course.id = 1
+    course.course_code = "prgi25"
+
+    student1 = Mock()
+    student1.id = 100
+    student1.name = "Alice Student"
+    student1.login_id = "alice@example.com"
+    student1.enrollments = [{"type": "StudentEnrollment"}]
+
+    student2 = Mock()
+    student2.id = 200
+    student2.name = "Bob Student"
+    student2.login_id = "bob@example.com"
+    student2.enrollments = [{"type": "StudentEnrollment"}]
+
+    course.get_users = Mock(return_value=[student1, student2])
+
+    def make_group(name, member_id):
+        group = Mock(spec=['name', 'course', 'get_users',
+                           'users', 'members_count'])
+        group.name = name
+        group.course = course
+        group.users = [{"id": member_id}]
+        group.members_count = 1
+        return group
+
+    groups = [make_group("Labb 1", 100), make_group("Labb 2", 200)]
+
+    args = Mock()
+    args.regex = ".*"
+    args.canvas_id = False
+    args.ladok = False
+    args.split_name = False
+    args.email = False
+
+    monkeypatch.setattr(
+        users_module,
+        "process_group_options",
+        lambda canvas, args: groups,
+    )
+
+    rows = list(users_module.make_user_rows_w_groups(
+        Mock(), args, ["student"]
+    ))
+
+    assert course.get_users.call_count == 1
+    assert [row[1] for row in rows] == ["Labb 1", "Labb 2"]
+    assert [row[2] for row in rows] == [
+        "alice@example.com", "bob@example.com",
+    ]
 @
 
 

--- a/src/canvaslms/cli/users.nw
+++ b/src/canvaslms/cli/users.nw
@@ -289,7 +289,77 @@ try:
 except AttributeError:
   course = group.category.course
 
-member_ids = {user.id for user in group.get_users()}
+member_ids = group_member_ids(group)
+@
+
+There are two ways to learn who is in a group.
+We can call [[group.get_users()]], which costs one API request per
+group---resolving all lab groups in a course this way refetches more or
+less the whole roster, one group at a time, on every run.
+Or we can ask Canvas to embed the members when we list the groups
+([[include=["users"]]] in [[process_group_options]]), which piggybacks all
+memberships onto a single, already cached request.
+
+We prefer the embedded membership but keep [[get_users()]] as a fallback,
+because the embedded list is not always trustworthy: the listing endpoint
+for group categories ignores the [[include]] parameter, and Canvas may
+truncate embedded lists.
+We therefore only trust the embedded list when its length matches the
+group's [[members_count]].
+The embedded members are plain JSON dictionaries rather than [[User]]
+objects, but we only need their IDs here; the fully populated [[User]]
+objects come from the course roster.
+<<functions>>=
+def group_member_ids(group):
+  """Return the set of user IDs of the members of ``group``.
+
+  Uses the membership embedded by ``include=["users"]`` when it's
+  complete, otherwise fetches the members through the API.
+  """
+  if group.users is not None and len(group.users) == group.members_count:
+    return {user["id"] for user in group.users}
+  return {user.id for user in group.get_users()}
+@
+
+Let's verify both ways of resolving membership: a complete embedded list
+should be used as is, while a truncated one (fewer embedded users than
+[[members_count]]) must fall back to fetching.
+
+<<test functions>>=
+def test_group_member_ids_uses_embedded_users():
+    """Complete embedded membership should not trigger an API call"""
+    group = Mock(spec=['users', 'members_count', 'get_users'])
+    group.users = [{"id": 100}, {"id": 200}]
+    group.members_count = 2
+
+    assert users_module.group_member_ids(group) == {100, 200}
+    group.get_users.assert_not_called()
+
+def test_group_member_ids_falls_back_when_truncated():
+    """Incomplete embedded membership should fall back to get_users()"""
+    group = Mock(spec=['users', 'members_count', 'get_users'])
+    group.users = [{"id": 100}]
+    group.members_count = 2
+
+    member = Mock(spec=['id'])
+    member.id = 100
+    other = Mock(spec=['id'])
+    other.id = 200
+    group.get_users = Mock(return_value=[member, other])
+
+    assert users_module.group_member_ids(group) == {100, 200}
+
+def test_group_member_ids_falls_back_without_embedding():
+    """A normalized group without embedded users should fetch members"""
+    group = Mock(spec=['users', 'members_count', 'get_users'])
+    group.users = None
+    group.members_count = 1
+
+    member = Mock(spec=['id'])
+    member.id = 100
+    group.get_users = Mock(return_value=[member])
+
+    assert users_module.group_member_ids(group) == {100}
 @
 
 Now let's verify the grouped path still recognizes students even when the
@@ -325,9 +395,11 @@ def test_make_user_rows_w_groups_filters_roles_in_course(monkeypatch):
     member_ta = Mock(spec=['id'])
     member_ta.id = 200
 
-    group = Mock(spec=['name', 'course', 'get_users'])
+    group = Mock(spec=['name', 'course', 'get_users',
+                       'users', 'members_count'])
     group.name = "mentorsgrupp 7-9"
     group.course = course
+    group.users = None  # normalized but not embedded
     group.get_users = Mock(return_value=[member_student, member_ta])
 
     args = Mock()
@@ -444,21 +516,27 @@ def filter_group_categories(course_list, regex):
 
 We can produce a list of groups in two ways:
 list all groups in a course or lists all groups in a group category.
-Fortunately, both the group category and course objects of [[canvasapi]] have a 
-method [[.get_groups()]], so thanks to Python's duck typing we can write short 
+Fortunately, both the group category and course objects of [[canvasapi]] have a
+method [[.get_groups()]], so thanks to Python's duck typing we can write short
 code.
+We forward any keyword arguments to [[.get_groups()]] so that callers can
+request extra data---[[process_group_options]] uses this to embed group
+memberships ([[include=["users"]]]) in the listing instead of fetching them
+group by group.
 <<functions>>=
-def filter_groups(items, regex):
+def filter_groups(items, regex, **kwargs):
   """
   Items is a list of either courses or group categories,
   regex is a regular expression.
   Returns all groups whose name match regex.
+
+  Keyword arguments are passed on to ``.get_groups()``.
   """
 
   name = re.compile(regex or ".*")
 
   for item in items:
-    for group in item.get_groups():
+    for group in item.get_groups(**kwargs):
       group = canvaslms.cli.utils.ensure_group_attrs(group)
       if name.search(group.name or ''):
         if isinstance(item, canvasapi.course.Course):
@@ -1192,6 +1270,12 @@ def add_group_option(parser):
 @
 
 We must also provide a function that can process these options.
+We ask Canvas to embed each group's members in the listing
+([[include=["users"]]]): all consumers of these groups go on to resolve
+membership, and the embedded lists let them do so without one API call per
+group (see [[group_member_ids]]).
+The group category listing endpoint ignores this parameter, in which case
+membership resolution falls back to [[get_users()]].
 <<functions>>=
 def process_group_options(canvas, args):
   """Processes the group/group category options, returns a list of groups"""
@@ -1201,11 +1285,13 @@ def process_group_options(canvas, args):
   if args.category:
     group_list = list(filter_groups(
       filter_group_categories(course_list, args.category),
-      args.group))
+      args.group,
+      include=["users"]))
   else:
     group_list = list(filter_groups(
       course_list,
-      args.group))
+      args.group,
+      include=["users"]))
   
   if not group_list:
     raise canvaslms.cli.EmptyListError("No groups found matching the criteria")

--- a/src/canvaslms/cli/utils.nw
+++ b/src/canvaslms/cli/utils.nw
@@ -31,6 +31,12 @@ Some Canvas endpoints intentionally return partial objects. Pages listed via
 [[get_pages()]] do not include [[body]], and courses listed via
 [[get_courses()]] do not include [[syllabus_body]]. For those cases we keep
 separate attribute lists for listing objects and fully fetched objects.
+
+The opposite also occurs: some attributes only appear when explicitly
+requested. Groups carry an embedded [[users]] list only when fetched with
+[[include=["users"]]]. Normalizing it to [[None]] lets membership code
+distinguish \enquote{not embedded} from \enquote{empty group} without
+[[getattr]] fallbacks at the use sites.
 <<constants>>=
 COURSE_ATTRS = (
     "id",
@@ -84,6 +90,7 @@ GROUP_ATTRS = (
     "id",
     "name",
     "members_count",
+    "users",
 )
 
 MODULE_ATTRS = (

--- a/src/canvaslms/hacks/attachment_cache.nw
+++ b/src/canvaslms/hacks/attachment_cache.nw
@@ -38,7 +38,10 @@ file, or if a student resubmits an unchanged file, we store it only once.
 
 The storage structure is:
 \begin{description}
-\item[Content files] [[<cache_dir>/attachments/<sha256>.dat]]
+\item[Content files] [[<cache_dir>/attachments/<sha256>.dat]], stored
+  Fernet-encrypted (see below); the hash is computed over the
+  \emph{plaintext}, so deduplication is unaffected by the randomized
+  encryption.
 \item[Metadata index] [[<cache_dir>/attachments/index.json]] mapping attachment
   IDs to hashes
 \end{description}
@@ -55,6 +58,38 @@ The index maps Canvas attachment IDs to cached file metadata:
   }
 }
 \end{minted}
+
+\subsection{Encrypting cached content}
+
+Cached attachments are student submissions---at least as sensitive as the
+course and student metadata that motivates encrypting the Canvas object
+cache in [[cache.nw]].
+We therefore apply the same protection: content files are encrypted with
+the same token-derived Fernet key as the Canvas object cache.
+The key is registered at program start by [[load_configured_canvas]] in
+[[cache.nw]] (the shared bootstrap for the command line and the package
+API), so this module never sees the token itself.
+If no key has been registered---library use without the bootstrap, or
+tests without the fixture---cache operations degrade to misses and no-ops
+rather than crash: the cache is an optimization, never a requirement.
+
+Consumers no longer get a path into the cache directory; they get the
+plaintext \emph{restored} (decrypted) into a destination of their choice,
+typically a temporary directory that is processed and discarded.
+Plaintext therefore exists only transiently during use.
+
+The index stays plaintext JSON: cleanup must read it without a key, and a
+human-readable index is invaluable when debugging cache problems.
+It holds metadata (filenames, sizes), not student work, and it is
+protected by file permissions instead: the cache directory is [[0o700]]
+and the index and content files [[0o600]].
+
+A [[.dat]] file written by an older, unencrypted canvaslms fails
+decryption.
+Consistent with the no-migration policy for the Canvas object cache, we
+don't convert such files: we discard the entry and the file, report a
+cache miss, and let the consumer re-download---the re-cached copy is then
+encrypted.
 
 \subsection{When attachments become stale}
 
@@ -88,6 +123,7 @@ import pytest
 import pathlib
 import json
 import time
+from cryptography.fernet import Fernet
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -98,14 +134,15 @@ import canvaslms.hacks.attachment_cache as attachment_cache
 @
 
 <<[[attachment_cache.py]]>>=
-"""Content-addressed cache for Canvas submission attachments"""
+"""Encrypted content-addressed cache for Canvas submission attachments"""
 
 import appdirs
+from cryptography.fernet import InvalidToken
 import hashlib
 import json
 import logging
+import os
 import pathlib
-import shutil
 import time
 from datetime import datetime, timedelta
 from typing import Any
@@ -113,6 +150,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 <<cache directory initialization>>
+<<encryption key state>>
 <<cache operations>>
 @
 
@@ -121,13 +159,19 @@ logger = logging.getLogger(__name__)
 We use [[appdirs]] to get the platform-specific cache directory, and create the
 necessary subdirectories on first use.
 
+We [[chmod]] explicitly instead of passing [[mode=]] to [[mkdir]]: the
+[[mode]] argument is filtered by the umask, and an explicit [[chmod]] also
+tightens directories and index files created by older canvaslms versions
+with default permissions.
+
 <<cache directory initialization>>=
 CACHE_DIR = pathlib.Path(appdirs.user_cache_dir("canvaslms")) / "attachments"
 INDEX_FILE = CACHE_DIR / "index.json"
 
 def _ensure_cache_dir():
-    """Create cache directory if it doesn't exist"""
+    """Create cache directory if it doesn't exist, user-only access"""
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    CACHE_DIR.chmod(0o700)
 
 def _load_index() -> dict[str, dict[str, Any]]:
     """Load the metadata index from disk"""
@@ -142,6 +186,28 @@ def _save_index(index: dict[str, dict[str, Any]]):
     _ensure_cache_dir()
     with open(INDEX_FILE, 'w') as f:
         json.dump(index, f, indent=2)
+    INDEX_FILE.chmod(0o600)
+@
+
+\subsection{Holding the encryption key}
+
+The module holds the Fernet instance in a module-level variable, set once
+at program start.
+We deliberately take a [[Fernet]] object rather than the Canvas token: this
+module then never handles the secret itself, and the (PBKDF2) key
+derivation stays in one place, [[cache.nw]].
+
+<<encryption key state>>=
+_fernet = None
+
+def set_fernet(fernet):
+    """Register the Fernet instance used to encrypt cached attachments.
+
+    Called once at program start; without it, all cache operations
+    degrade to cache misses and no-ops.
+    """
+    global _fernet
+    _fernet = fernet
 @
 
 \subsubsection{Test fixtures}
@@ -152,18 +218,22 @@ user's actual cache.
 
 The [[tmp_cache]] fixture creates a temporary cache directory and patches the
 module-level [[CACHE_DIR]] and [[INDEX_FILE]] variables to use it.
+It also registers a fresh Fernet key, since the encrypted cache degrades to
+no-ops without one.
 
 <<test fixtures>>=
 @pytest.fixture
 def tmp_cache(tmp_path):
-    """Provide a temporary cache directory for testing"""
+    """Provide a temporary cache directory and key for testing"""
     cache_dir = tmp_path / "attachments"
     cache_dir.mkdir()
     index_file = cache_dir / "index.json"
-    
+    test_fernet = Fernet(Fernet.generate_key())
+
     # Patch module-level constants
     with patch.object(attachment_cache, 'CACHE_DIR', cache_dir), \
-         patch.object(attachment_cache, 'INDEX_FILE', index_file):
+         patch.object(attachment_cache, 'INDEX_FILE', index_file), \
+         patch.object(attachment_cache, '_fernet', test_fernet):
         yield cache_dir
 @
 
@@ -277,30 +347,47 @@ def test_compute_hash_different_content(tmp_cache, tmp_path):
     assert hash1 != hash2
 @
 
-\subsection{Retrieving cached attachments}
+\subsection{Restoring cached attachments}
 
 When we need an attachment, we first check if it's in the cache.
-If found, we update the [[last_access]] timestamp to prevent premature cleanup,
-and return the path to the cached file.
+Since content files are encrypted, we cannot hand the caller a path into
+the cache directory as the old [[get_cached_attachment]] did; instead the
+caller names a destination and we \emph{restore} the plaintext there.
+On success we update the [[last_access]] timestamp to prevent premature
+cleanup.
+
+If decryption fails, the file is either a plaintext leftover from an older
+canvaslms or was encrypted under a different token.
+Either way it is useless to us, and merely reporting a miss would loop
+forever: the consumer would re-download, but [[cache_attachment]]'s
+deduplication would see the existing [[.dat]] file and never replace it.
+So we delete the unusable file along with its index entry; the re-cached
+copy is then encrypted under the current key.
 
 We log cache hits and misses at INFO level (consistent with [[cache.nw]]) so
 users can see cache effectiveness with the [[-v]] flag.
-This helps users understand when cached files are being reused, and when new
-downloads are required.
 
 <<cache operations>>=
-def get_cached_attachment(attachment_id: int) -> pathlib.Path | None:
+def restore_cached_attachment(attachment_id: int,
+                              dest_path: pathlib.Path) -> bool:
     """
-    Get cached file path for attachment, or None if not cached.
+    Decrypt the cached attachment into dest_path.
 
+    Returns True on success, False on cache miss (not cached, missing
+    or undecryptable content file, or no encryption key registered).
     Updates last_access timestamp on cache hit.
     """
+    if _fernet is None:
+        logger.debug(f"Attachment cache disabled (no encryption key): "
+                     f"{attachment_id}")
+        return False
+
     index = _load_index()
     attachment_key = str(attachment_id)
 
     if attachment_key not in index:
         logger.info(f"Attachment cache miss: {attachment_id}")
-        return None
+        return False
 
     entry = index[attachment_key]
     file_hash = entry["hash"]
@@ -311,7 +398,20 @@ def get_cached_attachment(attachment_id: int) -> pathlib.Path | None:
         logger.info(f"Attachment cache: stale entry removed: {attachment_id}")
         del index[attachment_key]
         _save_index(index)
-        return None
+        return False
+
+    try:
+        plaintext = _fernet.decrypt(cached_file.read_bytes())
+    except InvalidToken:
+        logger.info(f"Attachment cache: undecryptable content "
+                    f"(unencrypted legacy file or changed token), "
+                    f"discarding: {attachment_id}")
+        cached_file.unlink()
+        del index[attachment_key]
+        _save_index(index)
+        return False
+
+    pathlib.Path(dest_path).write_bytes(plaintext)
 
     # Update last access time
     entry["last_access"] = datetime.now().isoformat()
@@ -320,19 +420,20 @@ def get_cached_attachment(attachment_id: int) -> pathlib.Path | None:
     logger.info(f"Attachment cache hit: {attachment_id} "
                 f"({entry['filename']}, {entry['size'] / 1024:.1f}KB)")
 
-    return cached_file
+    return True
 @
 
-\subsubsection{Testing cache retrieval}
+\subsubsection{Testing cache restoration}
 
-We verify that retrieving cached attachments works correctly, including both
+We verify that restoring cached attachments works correctly, including both
 cache hits and misses.
 
 <<test functions>>=
-def test_get_cached_attachment_returns_none_for_missing(tmp_cache):
-    """Test that get_cached_attachment returns None for uncached attachments"""
-    cached_path = attachment_cache.get_cached_attachment(99999)
-    assert cached_path is None
+def test_restore_returns_false_for_missing(tmp_cache, tmp_path):
+    """Test that restoring an uncached attachment returns False"""
+    dest = tmp_path / "restored.txt"
+    assert attachment_cache.restore_cached_attachment(99999, dest) is False
+    assert not dest.exists()
 @
 
 \subsubsection{Testing stale entry handling}
@@ -341,38 +442,73 @@ When an index entry exists but the actual file is missing, we should detect
 and handle this gracefully.
 
 <<test functions>>=
-def test_get_cached_attachment_handles_missing_file(tmp_cache, tmp_path):
+def test_restore_handles_missing_file(tmp_cache, tmp_path):
     """Test that missing .dat file is detected and index cleaned up"""
     # Create and cache a file
     test_file = tmp_path / "test.txt"
     test_file.write_bytes(b"test content")
-    
+
     metadata = {
         "filename": "test.txt",
         "size": 100,
         "content_type": "text/plain"
     }
-    
+
     attachment_cache.cache_attachment(100, test_file, metadata)
-    
+
     # Manually delete the .dat file but leave index entry
-    cached_path = attachment_cache.get_cached_attachment(100)
-    cached_path.unlink()
-    
-    # Try to retrieve - should detect missing file
-    result = attachment_cache.get_cached_attachment(100)
-    assert result is None
-    
+    for dat_file in tmp_cache.glob("*.dat"):
+        dat_file.unlink()
+
+    # Try to restore - should detect missing file
+    dest = tmp_path / "restored.txt"
+    assert attachment_cache.restore_cached_attachment(100, dest) is False
+
     # Index should be cleaned up
     index = attachment_cache._load_index()
     assert "100" not in index
 @
 
+\subsubsection{Testing legacy plaintext entries}
+
+A [[.dat]] file written by an older, unencrypted canvaslms must be treated
+as a miss \emph{and} removed, so that the consumer's re-download replaces
+it with an encrypted copy instead of hitting the same undecryptable file
+forever.
+
+<<test functions>>=
+def test_legacy_plaintext_entry_becomes_miss(tmp_cache, test_file, tmp_path):
+    """Test that an unencrypted .dat file is discarded as a cache miss"""
+    metadata = {
+        "filename": "test.txt",
+        "size": 100,
+        "content_type": "text/plain"
+    }
+    attachment_cache.cache_attachment(1, test_file, metadata)
+
+    # Overwrite the encrypted file with plaintext, as an old version wrote
+    dat_file, = tmp_cache.glob("*.dat")
+    dat_file.write_bytes(test_file.read_bytes())
+
+    dest = tmp_path / "restored.txt"
+    assert attachment_cache.restore_cached_attachment(1, dest) is False
+
+    # The unusable file and its index entry are gone, so re-caching works
+    assert not dat_file.exists()
+    assert "1" not in attachment_cache._load_index()
+@
+
 \subsection{Caching new attachments}
 
-When we download a new attachment, we compute its hash, store the file by hash,
-and update the index.
+When we download a new attachment, we compute its hash, store the encrypted
+file by hash, and update the index.
 If a file with the same hash already exists (deduplication), we reuse it.
+The hash is computed over the plaintext, so two identical submissions
+deduplicate even though Fernet encryption is randomized.
+
+Without a registered encryption key we skip caching entirely---including
+the index update, since an index entry without a content file would just
+become a stale entry on the next restore.
 
 We log timing information for hash computation and file operations, following
 the pattern from [[cache.nw]] where pickle/encrypt/decrypt timing is logged.
@@ -388,13 +524,20 @@ since it represents a performance benefit worth highlighting.
 def cache_attachment(attachment_id: int, file_path: pathlib.Path,
                      metadata: dict[str, Any]):
     """
-    Cache an attachment file using content-addressed storage.
+    Cache an attachment file, encrypted, using content-addressed storage.
+
+    Does nothing if no encryption key is registered (see set_fernet).
 
     Args:
         attachment_id: Canvas attachment ID
         file_path: Path to the downloaded file
         metadata: Dictionary with 'filename', 'size', 'content_type'
     """
+    if _fernet is None:
+        logger.debug(f"Attachment cache disabled (no encryption key); "
+                     f"not caching {attachment_id}")
+        return
+
     _ensure_cache_dir()
 
     # Compute content hash with timing
@@ -408,13 +551,17 @@ def cache_attachment(attachment_id: int, file_path: pathlib.Path,
 
     cached_file = CACHE_DIR / f"{file_hash}.dat"
 
-    # Copy file to cache if not already present (deduplication)
+    # Encrypt into cache if not already present (deduplication)
     if not cached_file.exists():
-        copy_start = time.perf_counter()
-        shutil.copy2(file_path, cached_file)
-        copy_elapsed = time.perf_counter() - copy_start
+        encrypt_start = time.perf_counter()
+        encrypted = _fernet.encrypt(file_path.read_bytes())
+        fd = os.open(cached_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                     0o600)
+        with os.fdopen(fd, "wb") as f:
+            f.write(encrypted)
+        encrypt_elapsed = time.perf_counter() - encrypt_start
         logger.info(f"Attachment {attachment_id}: file cached "
-                    f"(copy: {copy_elapsed:.2f}s)")
+                    f"(encrypt and write: {encrypt_elapsed:.2f}s)")
     else:
         logger.info(f"Attachment {attachment_id}: content already cached (dedup)")
 
@@ -430,30 +577,63 @@ def cache_attachment(attachment_id: int, file_path: pathlib.Path,
     _save_index(index)
 @
 
-\subsubsection{Testing cache and retrieve operations}
+\subsubsection{Testing cache and restore operations}
 
-Now we verify the main operations: caching new attachments and retrieving
-cached attachments work together correctly.
+Now we verify the main operations: caching new attachments and restoring
+cached attachments work together correctly, and that what reaches the disk
+is actually ciphertext with user-only permissions.
 
 <<test functions>>=
-def test_cache_and_retrieve_attachment(tmp_cache, test_file):
-    """Test that we can cache and retrieve an attachment"""
+def test_cache_and_restore_attachment(tmp_cache, test_file, tmp_path):
+    """Test that we can cache and restore an attachment"""
     attachment_id = 12345
     metadata = {
         "filename": "test.txt",
         "size": test_file.stat().st_size,
         "content_type": "text/plain"
     }
-    
+
     # Cache the attachment
     attachment_cache.cache_attachment(attachment_id, test_file, metadata)
-    
-    # Retrieve it
-    cached_path = attachment_cache.get_cached_attachment(attachment_id)
-    
-    assert cached_path is not None
-    assert cached_path.exists()
-    assert cached_path.read_bytes() == test_file.read_bytes()
+
+    # Restore it
+    dest = tmp_path / "restored.txt"
+    assert attachment_cache.restore_cached_attachment(attachment_id, dest)
+
+    assert dest.read_bytes() == test_file.read_bytes()
+@
+
+<<test functions>>=
+def test_cached_file_is_encrypted_and_user_only(tmp_cache, test_file):
+    """The on-disk content file must be ciphertext with mode 0600"""
+    metadata = {
+        "filename": "test.txt",
+        "size": test_file.stat().st_size,
+        "content_type": "text/plain"
+    }
+    attachment_cache.cache_attachment(1, test_file, metadata)
+
+    dat_file, = tmp_cache.glob("*.dat")
+    assert test_file.read_bytes() not in dat_file.read_bytes()
+    assert dat_file.stat().st_mode & 0o777 == 0o600
+    assert attachment_cache.INDEX_FILE.stat().st_mode & 0o777 == 0o600
+@
+
+<<test functions>>=
+def test_no_key_degrades_to_noop(tmp_cache, test_file, tmp_path):
+    """Without a registered key, caching and restoring are no-ops"""
+    metadata = {
+        "filename": "test.txt",
+        "size": test_file.stat().st_size,
+        "content_type": "text/plain"
+    }
+
+    with patch.object(attachment_cache, '_fernet', None):
+        attachment_cache.cache_attachment(1, test_file, metadata)
+        assert attachment_cache._load_index() == {}
+
+        dest = tmp_path / "restored.txt"
+        assert attachment_cache.restore_cached_attachment(1, dest) is False
 @
 
 \subsubsection{Testing deduplication}
@@ -481,13 +661,12 @@ def test_deduplication_same_content(tmp_cache, tmp_path):
     # Cache both with different IDs
     attachment_cache.cache_attachment(100, file1, metadata)
     attachment_cache.cache_attachment(200, file2, metadata)
-    
-    # Both should point to the same cached file
-    cached1 = attachment_cache.get_cached_attachment(100)
-    cached2 = attachment_cache.get_cached_attachment(200)
-    
-    assert cached1 == cached2  # Same path due to deduplication
-    
+
+    # Both should restore from the cache
+    assert attachment_cache.restore_cached_attachment(100, tmp_path / "r1")
+    assert attachment_cache.restore_cached_attachment(200, tmp_path / "r2")
+    assert (tmp_path / "r1").read_bytes() == content
+
     # Only one .dat file should exist
     dat_files = list(tmp_cache.glob("*.dat"))
     assert len(dat_files) == 1
@@ -598,16 +777,18 @@ def test_cleanup_old_attachments(tmp_cache, tmp_path):
     
     # Run cleanup with 90-day threshold
     stats = attachment_cache.cleanup_old_attachments(max_age_days=90)
-    
+
     # Old attachment should be removed
     assert stats["files_removed"] == 1
     assert stats["bytes_freed"] > 0
-    
+
     # New attachment should still be cached
-    assert attachment_cache.get_cached_attachment(200) is not None
-    
+    assert attachment_cache.restore_cached_attachment(
+        200, tmp_path / "r200") is True
+
     # Old attachment should not be cached
-    assert attachment_cache.get_cached_attachment(100) is None
+    assert attachment_cache.restore_cached_attachment(
+        100, tmp_path / "r100") is False
 @
 
 <<test functions>>=
@@ -655,11 +836,12 @@ def test_cleanup_no_old_files(tmp_cache, tmp_path):
     
     # Run cleanup with 90-day threshold (file is recent)
     stats = attachment_cache.cleanup_old_attachments(max_age_days=90)
-    
+
     # No files should be removed
     assert stats["files_removed"] == 0
     assert stats["bytes_freed"] == 0
-    
+
     # File should still be cached
-    assert attachment_cache.get_cached_attachment(100) is not None
+    assert attachment_cache.restore_cached_attachment(
+        100, tmp_path / "r100") is True
 @

--- a/src/canvaslms/hacks/attachment_cache.nw
+++ b/src/canvaslms/hacks/attachment_cache.nw
@@ -77,6 +77,10 @@ Consumers no longer get a path into the cache directory; they get the
 plaintext \emph{restored} (decrypted) into a destination of their choice,
 typically a temporary directory that is processed and discarded.
 Plaintext therefore exists only transiently during use.
+Fernet has no streaming mode, so encrypting and restoring hold the whole
+file in memory (the old implementation streamed a plain copy); submission
+attachments are typically documents and source code, small enough that
+this is an acceptable price for encryption at rest.
 
 The index stays plaintext JSON: cleanup must read it without a key, and a
 human-readable index is invaluable when debugging cache problems.

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -4664,89 +4664,19 @@ For this, we first need a cache attribute.
 self.__cache = {}
 @
 
-\subsubsection{Defending against legacy cache shapes}
-
-Before the [[LazySubmission]] integration, [[cache_submissions]] stored each
-entry as a [[(submission, includes)]] tuple.
-Cache files written by those older builds survive on disk because
-[[load_canvas_cache]] in [[cache.nw]] performs no schema check---a tuple
-unpickles cleanly and only fails later, when the new reader dereferences
-[[lazy_submission._includes]].
-A proper schema version on the encrypted cache would catch this at load time
-but would force a full re-fetch on every shape change; that trade-off is
-tracked separately as issue~\#317.
-
-For now we keep the encrypted cache untouched and clean up lazily.
-Any entry whose runtime shape is not a [[LazySubmission]] is treated as
-unusable and discarded the first time we touch the cache.
-The very next [[get_submission]] / [[get_submissions]] call repopulates the
-slot with a fresh wrapper, so the rest of the cache (courses, users,
-assignment groups, \ldots) keeps serving traffic without a forced reset.
-
-We collect the offending [[uid]]s in a list before mutating the dict, because
-deleting during iteration over [[cache.values()]] would raise
-[[RuntimeError]].
-
-<<functions>>=
-def purge_legacy_submission_entries(cache):
-  """Discard cached submissions that predate LazySubmission.
-
-  Cache files written by older canvaslms versions stored each entry as
-  a ``(submission, includes)`` tuple.  The current reader expects a
-  ``LazySubmission`` wrapper and would raise ``AttributeError`` on the
-  first attribute access.  Called at the top of every cache-reading
-  path so legacy slots are evicted lazily and refetched on demand.
-  """
-  for uid in [u for u, entry in cache.items()
-              if not isinstance(entry, LazySubmission)]:
-    logger.info(
-      f"Cache miss (legacy entry shape, discarding): "
-      f"submission user_id={uid}"
-    )
-    del cache[uid]
-@
-
-Let's verify the helper drops legacy entries and leaves modern ones alone.
-
-<<test functions>>=
-class TestPurgeLegacySubmissionEntries:
-    """Test the legacy submission cache entry purger."""
-
-    def test_drops_tuple_entries(self):
-        """Pre-LazySubmission tuples should be evicted."""
-        cache = {1: ("submission", {"history"})}
-        purge_legacy_submission_entries(cache)
-        assert cache == {}
-
-    def test_keeps_lazy_submission_entries(self):
-        """Current-shape entries should survive."""
-        lazy = MagicMock(spec=LazySubmission)
-        cache = {1: lazy}
-        purge_legacy_submission_entries(cache)
-        assert cache == {1: lazy}
-
-    def test_mixed_cache_keeps_only_lazy(self):
-        """A mixed cache should retain only LazySubmission entries."""
-        lazy = MagicMock(spec=LazySubmission)
-        cache = {1: ("old", set()), 2: lazy, 3: None}
-        purge_legacy_submission_entries(cache)
-        assert cache == {2: lazy}
-
-    def test_empty_cache_is_noop(self):
-        """Purging an empty cache should not raise."""
-        cache = {}
-        purge_legacy_submission_entries(cache)
-        assert cache == {}
-@
+A cache file written by an older canvaslms may contain submissions in an
+older shape (before [[LazySubmission]], each entry was a
+[[(submission, includes)]] tuple).
+We don't migrate or purge such entries here: the loader in [[cache.nw]]
+stamps every cache file with [[CACHE_SCHEMA_VERSION]] and discards the
+whole cache on mismatch, so this code only ever sees entries written by
+the same schema version.
 
 Now we can treat how we get an individual submission.
 The lazy path only fetches when a submission is missing from the cache or when a
 caller requests additional [[include]] data.
 We keep the cache-hit diagnostics from [[master]], but we leave the staleness
 policy itself to [[LazySubmission._needs_refresh()]].
-The first thing we do on the cache is call [[purge_legacy_submission_entries]]
-so a stale-shape slot turns into a normal cache miss instead of an
-[[AttributeError]] later in this function.
 <<return submission of user>>=
 # canvasapi allows either User object or user ID.
 if isinstance(user, User):
@@ -4760,8 +4690,6 @@ if "include" in kwargs:
   to_include = set(kwargs["include"])
 else:
   to_include = set()
-
-purge_legacy_submission_entries(self.__cache)
 
 if uid in self.__cache:
   lazy_submission = self.__cache[uid]
@@ -4848,10 +4776,6 @@ def should_bulk_refresh_submissions(cache, student_ids=None):
 @
 
 Then the collection getter can choose whether to run that pre-check.
-We purge legacy-shape entries here as well, for the same reason as in
-[[<<return submission of user>>]]: the subsequent loops over
-[[self.__cache.values()]] read [[lazy_submission._includes]] and would crash
-on a tuple from a pre-[[LazySubmission]] cache.
 <<return a list of all submissions>>=
 if "include" in kwargs:
   to_include = set(kwargs["include"])
@@ -4860,7 +4784,6 @@ else:
 
 check_bulk_refresh = kwargs.pop("check_bulk_refresh", False)
 student_ids = kwargs.pop("student_ids", None)
-purge_legacy_submission_entries(self.__cache)
 need_refetch = self.__all_fetched is None
 
 if not need_refetch:

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1701,7 +1701,7 @@ else:
   stale_count = sum(1 for obj, _ in attr_cache.values() if outdated(obj))
   cache_msg = (f"Using cached {display_plural}: {len(attr_cache)} cached "
                f"(age: {cache_age.total_seconds()/60:.1f} minutes)")
-  if stale_count:
+  if stale_count and get_attr is not None:
     cache_msg += f", updating {stale_count} stale entries individually"
   logger.info(cache_msg)
   <<yield all objects in [[attr_cache]], update individual entries if needed>>
@@ -1721,10 +1721,12 @@ We log three critical decision points:
   or kwargs changed). This explains why a bulk refresh is happening.
 \item \textbf{Cached path usage}: When [[attr_all_fetched]] is set, we log the
   cache age and total size.
-  Only when entries are actually stale do we add that they will be updated
-  individually---an earlier version appended this unconditionally, which
-  made every cache hit read like a refetch and misled users into thinking
-  the cache was broken.
+  Only when entries are actually stale \emph{and} a singular method exists
+  to refresh them (the [[get_attr]] guard below) do we add that they will
+  be updated individually---an earlier version appended this
+  unconditionally, which made every cache hit read like a refetch and
+  misled users into thinking the cache was broken.
+  The message must only promise what the refresh loop will actually do.
 \item \textbf{Kwargs invalidation}: When [[must_update()]] detects that cached
   objects don't have the requested kwargs (e.g., new [[include]] fields), we log
   what changed before invalidating the cache. This explains why a bulk refresh

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -817,8 +817,23 @@ For these, we use [[include_singular=False]].
 
 We need to update two methods in sync, the [[get_x]] and [[get_xs]] methods.
 This is why we can't just use the decorators from [[cachetools]] or similar.
+
+The two wrappers are not independent: the plural method's cached path
+refreshes individual stale objects by calling the wrapped singular method,
+which it reaches through the closure variable [[get_attr]].
+When [[include_singular=False]], that variable is never bound, so the first
+stale object would crash the plural method with a [[NameError]]---a latent
+bug, since none of the plural-only entities (groups, group categories,
+assignment groups) produce objects that [[outdated()]] marks stale on their
+own.
+We initialize [[get_attr]] to [[None]] so the plural method can detect the
+configuration and skip individual refreshes; such entities instead rely
+entirely on the periodic bulk TTL machinery in [[outdated()]] for
+freshness.
 <<create decorator functions and update [[cls]]>>=
 <<update constructor with new attributes>>
+
+get_attr = None
 
 if self.__include_singular:
   <<update the singular method>>
@@ -1791,9 +1806,17 @@ Without this update, the stale object remains in the cache, causing the same
 object to be re-fetched on every subsequent call---a significant performance bug
 for objects like pages that are marked stale when they lack complete data
 (e.g., missing [[body]] attribute from bulk fetches).
+
+For plural-only entities ([[include_singular=False]]), [[get_attr]] is
+[[None]] and there is no singular method to refresh a single object with,
+so we yield the cached object as is.
+The order of the conjunction matters: [[outdated()]] must run even when we
+cannot refresh, because it has the side effect of resetting expired
+[[_all_fetched]] timestamps on the object's own child caches, which is what
+drives the periodic bulk refreshes.
 <<yield all objects in [[attr_cache]], update individual entries if needed>>=
 for obj, obj_kwargs in attr_cache.values():
-  if outdated(obj):
+  if outdated(obj) and get_attr is not None:
     obj_key = getattr(obj, cache_key)
     reason = get_staleness_reason(obj)
     reason_str = f" (reason: {reason})" if reason else ""
@@ -1808,6 +1831,43 @@ for obj, obj_kwargs in attr_cache.values():
 <<yield all objects in [[attr_cache]]>>=
 for obj, _ in attr_cache.values():
   yield obj
+@
+
+Let's verify that a plural-only entity survives a stale cached object:
+before the [[get_attr]] guard, this raised [[NameError]] inside the
+generator instead of yielding the object.
+
+<<test functions>>=
+class TestPluralOnlyStaleObjects:
+    """Test cached path for entities without a singular get method"""
+
+    def test_stale_object_without_singular_is_yielded(self):
+        """A stale object should be yielded as is, not crash with NameError"""
+        class TestClass:
+            def __init__(self):
+                pass
+            def get_items(self, **kwargs):
+                obj = MagicMock()
+                obj.id = 1
+                obj.grade = "F"  # non-passing grade, can become stale
+                return [obj]
+
+        CacheGetMethods("item", include_singular=False)(TestClass)
+        instance = TestClass()
+
+        # First call - bulk fetch
+        list(instance.get_items())
+
+        # Make the cached object stale (TTL expired)
+        obj, kwargs = instance.item_cache[1]
+        obj._fetched_at = datetime.now() - timedelta(minutes=6)
+        instance.item_cache[1] = (obj, kwargs)
+
+        # Second call must yield the stale object without refreshing
+        result = list(instance.get_items())
+
+        assert len(result) == 1
+        assert result[0] is obj
 @
 
 \subsubsection{Testing cache timing and logging}
@@ -3497,6 +3557,27 @@ Note that groups can be fetched from both [[Course]] and [[GroupCategory]]
 objects, so we cache on both.
 For [[group_category]], the plural is irregular (``categories'' not
 ``categorys''), so we specify [[plural_name="group_categories"]].
+
+Group \emph{membership} needs caching too.
+Commands that operate on groups---listing users by group, grading by
+group---resolve the members of every matching group through
+[[Group.get_users()]].
+Left uncached, that costs one API call per group on every invocation; for a
+course whose lab groups partition all students, this amounts to refetching
+the whole roster over the network on every run, and nothing ever persists
+between runs.
+We therefore wrap [[Group]] with a user cache as well.
+Memberships then live in [[group.user_cache]], persist inside the pickled
+[[Canvas]] object (groups are reachable from the course's group cache), and
+expire through the same [[user_all_fetched]] TTL
+([[USER_CACHE_TTL_DAYS]] days) that [[outdated()]] applies to any object
+carrying that attribute: every traversal of the cached groups listing calls
+[[outdated(group)]], which resets an expired [[user_all_fetched]] and
+thereby triggers a membership refetch on the next [[get_users()]] call.
+Like the other group-related methods, [[Group]] has no singular
+[[get_user()]], so we use [[include_singular=False]]; cached members are
+never refreshed one by one, which is safe because plain [[User]] objects
+never turn stale on their own.
 <<functions>>=
 def make_course_groups_cacheable():
   import canvasapi.course
@@ -3508,6 +3589,40 @@ def make_course_groups_cacheable():
     include_singular=False)(canvasapi.course.Course)
   canvasapi.group.GroupCategory = CacheGetMethods("group",
     include_singular=False)(canvasapi.group.GroupCategory)
+  canvasapi.group.Group = CacheGetMethods("user",
+    include_singular=False)(canvasapi.group.Group)
+@
+
+Let's verify that group membership is fetched once and then served from the
+cache: a second [[get_users()]] call must not invoke the underlying API
+method again.
+
+<<test functions>>=
+class TestGroupUserCaching:
+    """Test that group membership is cached across get_users() calls"""
+
+    def test_second_get_users_call_uses_cache(self):
+        """Second get_users() call should not hit the API again"""
+        call_count = {"count": 0}
+
+        class TestGroup:
+            def __init__(self):
+                pass
+            def get_users(self, **kwargs):
+                call_count["count"] += 1
+                user = MagicMock()
+                user.id = 100
+                return [user]
+
+        CacheGetMethods("user", include_singular=False)(TestGroup)
+        group = TestGroup()
+
+        first = list(group.get_users())
+        second = list(group.get_users())
+
+        assert call_count["count"] == 1
+        assert len(first) == len(second) == 1
+        assert first[0] is second[0]
 @
 
 

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1699,9 +1699,11 @@ if not attr_all_fetched:
 else:
   cache_age = datetime.now() - attr_all_fetched
   stale_count = sum(1 for obj, _ in attr_cache.values() if outdated(obj))
-  logger.info(f"Using cached {display_plural}: {len(attr_cache)} cached "
-              f"(age: {cache_age.total_seconds()/60:.1f} minutes, "
-              f"{stale_count} stale), updating stale entries individually")
+  cache_msg = (f"Using cached {display_plural}: {len(attr_cache)} cached "
+               f"(age: {cache_age.total_seconds()/60:.1f} minutes)")
+  if stale_count:
+    cache_msg += f", updating {stale_count} stale entries individually"
+  logger.info(cache_msg)
   <<yield all objects in [[attr_cache]], update individual entries if needed>>
 @
 
@@ -1718,8 +1720,11 @@ We log three critical decision points:
   whether this is the first fetch (cold cache) or a cache invalidation (TTL expired
   or kwargs changed). This explains why a bulk refresh is happening.
 \item \textbf{Cached path usage}: When [[attr_all_fetched]] is set, we log the
-  cache age, total size, and how many entries are stale (requiring individual refresh).
-  This provides visibility into cache health and effectiveness.
+  cache age and total size.
+  Only when entries are actually stale do we add that they will be updated
+  individually---an earlier version appended this unconditionally, which
+  made every cache hit read like a refetch and misled users into thinking
+  the cache was broken.
 \item \textbf{Kwargs invalidation}: When [[must_update()]] detects that cached
   objects don't have the requested kwargs (e.g., new [[include]] fields), we log
   what changed before invalidating the cache. This explains why a bulk refresh

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -3581,6 +3581,10 @@ expire through the same [[user_all_fetched]] TTL
 carrying that attribute: every traversal of the cached groups listing calls
 [[outdated(group)]], which resets an expired [[user_all_fetched]] and
 thereby triggers a membership refetch on the next [[get_users()]] call.
+Note that this cache and its TTL govern the [[get_users()]] callers; the
+grouped user listing in [[users.nw]] \emph{prefers} the membership embedded
+in the groups listing itself, which instead refreshes on the groups cadence
+([[GROUP_CACHE_TTL_DAYS]] days).
 Like the other group-related methods, [[Group]] has no singular
 [[get_user()]], so we use [[include_singular=False]]; cached members are
 never refreshed one by one, which is safe because plain [[User]] objects


### PR DESCRIPTION
- **Cache group memberships in Group.get_users()**
- **Mention individual updates only when entries are stale**
- **Embed group memberships in the cached groups listing**
- **Filter each course roster once in grouped users listing**
- **Version the persisted Canvas cache**
- **Remove legacy submission cache migration**
- **Make cache saves atomic and log cache failures**
- **Encrypt cached submission attachments**
- **Promise individual updates only when refresh can happen**
- **Correct freshness and memory claims in cache prose**
