### PR TITLE
speed up results prefetch

### DIFF
--- a/src/canvaslms/cli/cache.nw
+++ b/src/canvaslms/cli/cache.nw
@@ -657,6 +657,12 @@ We provide subcommands for different cache management operations:
 \item[[cache clear-attachments]] Removes old cached attachment files
 \end{description}
 
+The command's description interpolates the live TTL values (imported above) so
+the help always reflects the effective windows, and it names the
+[[CANVASLMS_*]] environment variables that override them.  Surfacing the
+override knobs here, next to the values they control, is the discoverable place
+for a user wondering why the cache feels stale or stubborn.
+
 <<functions>>=
 def add_command(subp):
   """Adds the cache command to argparse parser"""
@@ -678,6 +684,12 @@ submissions) encrypted on disk. Objects are refreshed based on their type:
 - Other objects: {DEFAULT_CACHE_TTL_DAYS} days
 
 Submissions with passing grades (A, P, complete) are never refreshed.
+
+These windows can be tuned via environment variables (minutes for submissions,
+days for the rest): CANVASLMS_SUBMISSION_TTL_MINUTES,
+CANVASLMS_USER_CACHE_TTL_DAYS, CANVASLMS_GROUP_CACHE_TTL_DAYS,
+CANVASLMS_QUIZ_CACHE_TTL_DAYS, and CANVASLMS_DEFAULT_CACHE_TTL_DAYS. Raise them
+to reuse the cache across more runs, or lower them to see fresher data sooner.
 
 The attachment cache stores downloaded submission files using content-addressed
 storage. Files not accessed in 90 days can be cleaned with clear-attachments.

--- a/src/canvaslms/cli/results.nw
+++ b/src/canvaslms/cli/results.nw
@@ -396,6 +396,101 @@ submissions_list = submissions.filter_submissions(
   users_list)
 @
 
+\subsection{Warming the submission cache for the summary paths}
+\label{sec:prefetch-submissions}
+
+The grade path above reads each submission directly from [[submissions_list]],
+so the single bulk [[list_submissions]] call already pays for every student in
+one request per assignment.  The remaining paths---assignment groups ([[-A]]),
+modules ([[-M]]) and every [[--missing]] report---are different: they hand the
+assignments and users to a summary module (\cref{custom-summary-modules}) or to
+[[missing_assignments]], both of which loop \emph{per user} and call the
+singular [[assignment.get_submission(user)]].
+
+On a cold cache that singular call fetches one student at a time, so a group of
+$a$ assignments and $u$ students costs $a \times u$ requests.  The plural
+[[get_submissions]] behind [[list_submissions]] instead fetches a whole
+assignment in one request and marks it fully fetched, after which those
+singular lookups become cache hits.  We therefore \emph{warm} the cache with
+one bulk fetch per assignment before entering the per-user loop, which collapses
+the cost back to $a$ requests.
+
+The warming only pays off when there are enough students to amortise it.  A cold
+bulk fetch always pulls the assignment's whole roster---Canvas has no cheap
+per-student bulk endpoint---so for a handful of students the individual lookups
+are actually cheaper.  We gate on [[BULK_REFRESH_MIN_COUNT]], the same threshold
+the cache layer uses to choose between many individual refreshes and one bulk
+refresh; the caller is the natural place for this decision because only it knows
+the total student count up front, whereas the singular cache path sees one user
+at a time.
+
+We request [["submission_history"]] in [[include]], which is a superset of what
+every bundled summary module asks for, so their singular lookups find the cached
+includes sufficient and never refetch.  As in the grade path, we scope the
+bulk-refresh pre-check to the students we will actually read via
+[[student_ids]].
+<<functions>>=
+def prefetch_submissions(assignments_list, users_list):
+  """
+  Warm the per-assignment submission cache with one bulk fetch per assignment.
+
+  The grade, group, module and missing-assignment paths look up submissions one
+  user at a time; warming the cache first turns those lookups into cache hits
+  instead of one request per (user, assignment).
+
+  Skipped for small user sets, where the per-user lookups the cache already
+  performs are cheaper than pulling each assignment's whole roster.
+  """
+  if len(users_list) < canvaslms.hacks.canvasapi.BULK_REFRESH_MIN_COUNT:
+    return
+
+  student_ids = {user.id for user in users_list}
+  for _ in submissions.list_submissions(
+      assignments_list,
+      include=["submission_history"],
+      check_bulk_refresh=True,
+      student_ids=student_ids):
+    pass
+@
+
+Let's verify the guard and the scoping.  Below the threshold we must not touch
+the network at all; at or above it we must issue exactly one scoped bulk fetch
+carrying the history include.
+
+<<test functions>>=
+def test_prefetch_submissions_skips_small_user_sets(monkeypatch):
+  recorded = []
+  monkeypatch.setattr(
+    results_module.submissions, "list_submissions",
+    lambda *args, **kwargs: recorded.append(kwargs) or iter([]))
+  monkeypatch.setattr(
+    results_module.canvaslms.hacks.canvasapi,
+    "BULK_REFRESH_MIN_COUNT", 3)
+
+  users = [SimpleNamespace(id=i) for i in range(2)]
+  results_module.prefetch_submissions(["assignment"], users)
+
+  assert recorded == []
+
+
+def test_prefetch_submissions_warms_large_user_sets(monkeypatch):
+  recorded = []
+  monkeypatch.setattr(
+    results_module.submissions, "list_submissions",
+    lambda *args, **kwargs: recorded.append(kwargs) or iter([]))
+  monkeypatch.setattr(
+    results_module.canvaslms.hacks.canvasapi,
+    "BULK_REFRESH_MIN_COUNT", 3)
+
+  users = [SimpleNamespace(id=i) for i in range(3)]
+  results_module.prefetch_submissions(["assignment"], users)
+
+  assert len(recorded) == 1
+  assert recorded[0]["check_bulk_refresh"] is True
+  assert recorded[0]["include"] == ["submission_history"]
+  assert recorded[0]["student_ids"] == {0, 1, 2}
+@
+
 \subsection{Producing a list of missing assignments for the [[-a]] path}
 \label{sec:summarize-assignments-missing}
 
@@ -418,6 +513,8 @@ lets them treat [[-a --missing]] and [[-A --missing]] identically.
 <<produce a list of missing assignments for assignment filter>>=
 assignments_list = list(assignments.process_assignment_option(canvas, args))
 users_list = set(users.process_user_or_group_option(canvas, args))
+
+prefetch_submissions(assignments_list, users_list)
 
 <<load the correct missing module as [[missing]]>>
 <<let [[missing_results]] be the result of [[missing.missing_assignments]]>>
@@ -553,6 +650,8 @@ def summarize_assignment_groups(canvas, args):
   all_assignments = list(assignments.process_assignment_option(canvas, args))
   users_list = set(users.process_user_or_group_option(canvas, args))
 
+  prefetch_submissions(all_assignments, users_list)
+
   for course in courses_list:
     ag_list = assignments.filter_assignment_groups(
       course, args.assignment_group)
@@ -599,6 +698,8 @@ def summarize_modules(canvas, args):
   courses_list = courses.process_course_option(canvas, args)
   all_assignments = list(assignments.process_assignment_option(canvas, args))
   users_list = set(users.process_user_or_group_option(canvas, args))
+
+  prefetch_submissions(all_assignments, users_list)
 
   for course in courses_list:
     module_list = modules.filter_modules(course, args.module)

--- a/src/canvaslms/cli/results.nw
+++ b/src/canvaslms/cli/results.nw
@@ -491,15 +491,161 @@ def test_prefetch_submissions_warms_large_user_sets(monkeypatch):
   assert recorded[0]["student_ids"] == {0, 1, 2}
 @
 
+\subsection{Scoping students to their course round}
+\label{sec:scope-users-by-course}
+
+The three summary paths each resolve their students once, with
+[[process_user_or_group_option]], and that call returns the \emph{union} of
+students across every course round matched by [[-c]].  A student who took the
+course in an earlier round, but not the one we are reporting on, still sits in
+that union.
+
+Resolving the students once is convenient, but it turns the per-user submission
+lookup into a cross-round trap.  Each round is summarized against its own
+assignments (\cref{custom-summary-modules}), yet the lookup loops over
+\emph{every} student in the union.  Asking Canvas for a round's assignment
+submission by a student who never enrolled in that round is a question with no
+answer: Canvas replies [[404]].  On the grade path the empty result is silently
+dropped, so only the wasted round-trip shows; on the missing path the [[404]]
+is read by [[missing_assignments]] as \enquote{no submission exists}, and the
+student is wrongly reported as missing an assignment from a round they were
+never part of.
+
+The cure is to ask only the questions that can have answers: before summarizing
+a round, restrict the union to the students actually enrolled in that round.
+We intersect by Canvas user id against the round's roster.  Intersecting rather
+than re-resolving is what keeps the caller's filters intact---[[-u]], [[-r]]
+and [[-g]] have already shaped the union, so a [[-u]]-matched student simply
+appears for exactly the rounds they belong to, and no filter has to be
+re-applied here.
+
+We deliberately scope the \emph{students}, not the loop.  Collapsing the
+per-round loop into a single course would foreclose a future where a student's
+work in one round counts toward another round's grade; keeping the loop and
+narrowing the students leaves that door open.  Combining rounds then becomes a
+matter of \emph{widening} the assignments handed to the summary, not of undoing
+this scoping.
+
+The roster comes from [[list_users]], which fetches
+[[course.get_users(include=["enrollments"])]]---the very call the user paths
+already made and cached---so the intersection costs a cache hit, not a fresh
+request.  Passing no roles returns the whole roster; the role filter, if any,
+is already baked into [[users_list]].
+<<functions>>=
+def filter_users_by_course(users_list, course):
+  """
+  Restrict users_list to the students enrolled in course.
+
+  The summary paths gather students across every matched course round into one
+  set, but each round must be summarized against only its own students.
+  Probing a submission for a student not enrolled in the round's course makes a
+  doomed singular request that Canvas answers with 404 (and, on the missing
+  path, yields a spurious "missing" row). We intersect by Canvas user id
+  against the round's roster, so every filter already applied to users_list
+  (-u, -r, -g) is preserved.
+  """
+  roster_ids = {user.id for user in users.list_users([course], [])}
+  return [user for user in users_list if user.id in roster_ids]
+@
+
+Let's verify the intersection: only roster members survive, the rest are
+dropped, and an already-narrowed [[users_list]] (as a [[-u]] query produces) is
+returned untouched when its student is on the roster.
+
+<<test functions>>=
+def test_filter_users_by_course_keeps_only_enrolled(monkeypatch):
+  roster = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+  monkeypatch.setattr(
+    results_module.users, "list_users",
+    lambda courses, roles: roster)
+
+  users_list = [SimpleNamespace(id=1), SimpleNamespace(id=2),
+                SimpleNamespace(id=3)]
+  scoped = results_module.filter_users_by_course(users_list, "course")
+
+  assert {user.id for user in scoped} == {1, 2}
+
+
+def test_filter_users_by_course_preserves_a_single_user_query(monkeypatch):
+  roster = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+  monkeypatch.setattr(
+    results_module.users, "list_users",
+    lambda courses, roles: roster)
+
+  # A -u query has already narrowed users_list to one student.
+  users_list = [SimpleNamespace(id=2)]
+  scoped = results_module.filter_users_by_course(users_list, "course")
+
+  assert [user.id for user in scoped] == [2]
+
+
+def test_filter_users_by_course_drops_user_absent_from_round(monkeypatch):
+  roster = [SimpleNamespace(id=1)]
+  monkeypatch.setattr(
+    results_module.users, "list_users",
+    lambda courses, roles: roster)
+
+  # The -u student belongs to another round, not this one.
+  users_list = [SimpleNamespace(id=2)]
+  scoped = results_module.filter_users_by_course(users_list, "course")
+
+  assert scoped == []
+@
+
 \subsection{Producing a list of missing assignments for the [[-a]] path}
 \label{sec:summarize-assignments-missing}
 
-The missing path mirrors the [[-A]] path, but without the outer
-course/group loop: [[process_assignment_option]] already returns a flat
-list of assignments with their [[course]] attached, so we can hand that
-list directly to [[missing.missing_assignments]].
+Unlike the [[-A]] path, this one has no course/group loop of its own:
+[[process_assignment_option]] hands back a single flat list of assignments,
+potentially spanning several course rounds at once.
+\Cref{sec:scope-users-by-course} showed why we must still summarize each round
+against only its own students, so before reporting we group the flat list by
+course and scope the students to each group in turn.
 We wrap the users in a [[set]] the same way [[summarize_assignment_groups]]
 does, to avoid duplicate rows when a user appears under several filters.
+
+To split the flat list per round we bucket assignments by their course.
+[[process_assignment_option]] attaches a [[course]] to every assignment (we
+already rely on it for the [[course_code]] column below), so we key by
+[[course.id]] and keep one [[Course]] object per bucket to hand to
+[[filter_users_by_course]].
+<<functions>>=
+def group_assignments_by_course(assignments_list):
+  """
+  Group assignments by their course, returning (course, assignments) pairs.
+
+  Used by the -a path, which receives a flat assignment list spanning every
+  matched course round and must summarize each round against only its own
+  students.
+  """
+  groups = {}
+  for assignment in assignments_list:
+    course = assignment.course
+    if course.id not in groups:
+      groups[course.id] = (course, [])
+    groups[course.id][1].append(assignment)
+  return list(groups.values())
+@
+
+We verify that assignments from two rounds land in separate buckets, each
+carrying its own [[Course]] object and assignment list.
+
+<<test functions>>=
+def test_group_assignments_by_course_buckets_per_round():
+  round1 = SimpleNamespace(id=10)
+  round2 = SimpleNamespace(id=20)
+  a1 = SimpleNamespace(name="H1", course=round1)
+  a2 = SimpleNamespace(name="H2", course=round1)
+  a3 = SimpleNamespace(name="H1", course=round2)
+
+  groups = {
+    course.id: assignments
+    for course, assignments in
+    results_module.group_assignments_by_course([a1, a2, a3])}
+
+  assert groups[10] == [a1, a2]
+  assert groups[20] == [a3]
+@
 
 The row shape matches the other missing paths:
 [[(course code, component, identifier, missing assignment, reason)]].
@@ -511,21 +657,23 @@ That coincidence is intentional: downstream tools already consume the
 five-column contract from the [[-A]] path, and keeping column~2 stable
 lets them treat [[-a --missing]] and [[-A --missing]] identically.
 <<produce a list of missing assignments for assignment filter>>=
-assignments_list = list(assignments.process_assignment_option(canvas, args))
-users_list = set(users.process_user_or_group_option(canvas, args))
+all_assignments = list(assignments.process_assignment_option(canvas, args))
+all_users = set(users.process_user_or_group_option(canvas, args))
 
-prefetch_submissions(assignments_list, users_list)
+prefetch_submissions(all_assignments, all_users)
 
 <<load the correct missing module as [[missing]]>>
-<<let [[missing_results]] be the result of [[missing.missing_assignments]]>>
-for user, assignment, reason in missing_results:
-  yield [
-    assignment.course.course_code,
-    assignment.name,
-    result_identifier(user, args),
-    assignment.name,
-    reason
-  ]
+for course, assignments_list in group_assignments_by_course(all_assignments):
+  users_list = filter_users_by_course(all_users, course)
+  <<let [[missing_results]] be the result of [[missing.missing_assignments]]>>
+  for user, assignment, reason in missing_results:
+    yield [
+      assignment.course.course_code,
+      assignment.name,
+      result_identifier(user, args),
+      assignment.name,
+      reason
+    ]
 @
 
 Let's pin the behaviour of the default [[missing_assignments]] helper that
@@ -635,9 +783,15 @@ In this case, we want to have one assignment group per row in the output.
 We want to output course, assignment group, student identifier, summarized
 grade based on all assignments in the group and the latest submission date.
 
-Unlike the previous case, here we must maintain the structure of which 
-assignments belong to which assignment group so that we can check easily that a 
+Unlike the previous case, here we must maintain the structure of which
+assignments belong to which assignment group so that we can check easily that a
 user has passed all assignments in the group.
+We resolve the students once into [[all_users]] (the union across every matched
+round), warm the cache for all of them, and then, per round, narrow that union
+to the round's own students with [[filter_users_by_course]]
+(\cref{sec:scope-users-by-course}) before summarizing.
+The grade and missing chunks both read [[users_list]], so rebinding it inside
+the loop scopes both without touching either chunk.
 <<functions>>=
 def summarize_assignment_groups(canvas, args):
   """
@@ -648,11 +802,12 @@ def summarize_assignment_groups(canvas, args):
 
   courses_list = courses.process_course_option(canvas, args)
   all_assignments = list(assignments.process_assignment_option(canvas, args))
-  users_list = set(users.process_user_or_group_option(canvas, args))
+  all_users = set(users.process_user_or_group_option(canvas, args))
 
-  prefetch_submissions(all_assignments, users_list)
+  prefetch_submissions(all_assignments, all_users)
 
   for course in courses_list:
+    users_list = filter_users_by_course(all_users, course)
     ag_list = assignments.filter_assignment_groups(
       course, args.assignment_group)
 
@@ -697,11 +852,12 @@ def summarize_modules(canvas, args):
 
   courses_list = courses.process_course_option(canvas, args)
   all_assignments = list(assignments.process_assignment_option(canvas, args))
-  users_list = set(users.process_user_or_group_option(canvas, args))
+  all_users = set(users.process_user_or_group_option(canvas, args))
 
-  prefetch_submissions(all_assignments, users_list)
+  prefetch_submissions(all_assignments, all_users)
 
   for course in courses_list:
+    users_list = filter_users_by_course(all_users, course)
     module_list = modules.filter_modules(course, args.module)
 
     for module in module_list:

--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -1498,8 +1498,9 @@ class TestSingularMethodCaching:
 
         # First call
         result1 = instance.get_submission(1)
-        # Make it outdated (> 5 minutes old)
-        result1._fetched_at = datetime.now() - timedelta(minutes=6)
+        # Make it outdated (past the submission TTL)
+        result1._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
         instance.submission_cache[1] = (result1, {})
 
         # Second call should refetch
@@ -1867,7 +1868,8 @@ class TestPluralOnlyStaleObjects:
 
         # Make the cached object stale (TTL expired)
         obj, kwargs = instance.item_cache[1]
-        obj._fetched_at = datetime.now() - timedelta(minutes=6)
+        obj._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
         instance.item_cache[1] = (obj, kwargs)
 
         # Second call must yield the stale object without refreshing
@@ -2160,7 +2162,8 @@ class TestPluralMethodCaching:
 
         # Make it outdated
         obj, kwargs = instance.submission_cache[1]
-        obj._fetched_at = datetime.now() - timedelta(minutes=6)
+        obj._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
         instance.submission_cache[1] = (obj, kwargs)
 
         # Second call should refetch the outdated object
@@ -2843,17 +2846,33 @@ BULK_REFRESH_THRESHOLD = float(os.environ.get('CANVASLMS_BULK_THRESHOLD', '0.2')
 BULK_REFRESH_MIN_COUNT = int(os.environ.get('CANVASLMS_BULK_MIN_COUNT', '3'))
 @
 
+\label{sec:cache-ttl-constants}
+
 We define constants for all cache time-to-live (TTL) values to ensure
-consistency between the [[outdated()]] function and log messages.
-When these values are tuned for performance, both the cache behavior and
-diagnostic messages update automatically.
+consistency between the [[outdated()]] function, [[LazySubmission]] and the
+staleness log messages.  When these values are tuned for performance, both the
+cache behavior and diagnostic messages update automatically.
+
+Each TTL is also read from the environment, following the same
+[[CANVASLMS_*]] pattern as the [[BULK_REFRESH_*]] thresholds above.  This lets a
+user trade freshness for speed without editing the source: a long-running
+grading session can extend the submission window, while a script that must see
+the very latest grades can shorten it.  We default the submission TTL to
+20~minutes---long enough that back-to-back [[results]] runs reuse the cache
+rather than re-fetching every in-progress submission, while final grades in
+[[NOREFRESH_GRADES]] stay cached regardless.
 <<constants>>=
-# Cache TTL constants
-SUBMISSION_TTL_MINUTES = 5
-DEFAULT_CACHE_TTL_DAYS = 7
-USER_CACHE_TTL_DAYS = 2
-GROUP_CACHE_TTL_DAYS = 5
-QUIZ_CACHE_TTL_DAYS = 3
+# Cache TTL constants (overridable via environment)
+SUBMISSION_TTL_MINUTES = int(
+  os.environ.get("CANVASLMS_SUBMISSION_TTL_MINUTES", "20"))
+DEFAULT_CACHE_TTL_DAYS = int(
+  os.environ.get("CANVASLMS_DEFAULT_CACHE_TTL_DAYS", "7"))
+USER_CACHE_TTL_DAYS = int(
+  os.environ.get("CANVASLMS_USER_CACHE_TTL_DAYS", "2"))
+GROUP_CACHE_TTL_DAYS = int(
+  os.environ.get("CANVASLMS_GROUP_CACHE_TTL_DAYS", "5"))
+QUIZ_CACHE_TTL_DAYS = int(
+  os.environ.get("CANVASLMS_QUIZ_CACHE_TTL_DAYS", "3"))
 @
 
 Some query arguments are additive, such as [[include]], and fit naturally in a
@@ -3006,27 +3025,30 @@ class TestOutdated:
         assert not outdated(submission)
 
     def test_non_passing_grade_recent_not_outdated(self):
-        """Recent non-passing grade (< 5 min) should not be outdated"""
+        """Non-passing grade within the TTL should not be outdated"""
         submission = MagicMock()
         submission.grade = "F"
-        submission._fetched_at = datetime.now() - timedelta(minutes=4)
+        submission._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES - 1)
 
         assert not outdated(submission)
 
     def test_non_passing_grade_old_is_outdated(self):
-        """Old non-passing grade (> 5 min) should be outdated"""
+        """Non-passing grade past the TTL should be outdated"""
         submission = MagicMock()
         submission.grade = "B"
-        submission._fetched_at = datetime.now() - timedelta(minutes=6)
+        submission._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
 
         assert outdated(submission)
 
-    def test_non_passing_grade_exactly_5min_not_outdated(self):
-        """Exactly 5 minutes should not trigger update (not >5)"""
+    def test_non_passing_grade_at_ttl_not_outdated(self):
+        """Exactly at the TTL should not trigger update (not >TTL)"""
         submission = MagicMock()
         submission.grade = "C"
-        # Set to just under 5 minutes to account for execution time
-        submission._fetched_at = datetime.now() - timedelta(minutes=5, seconds=-1)
+        # Just under the TTL to account for execution time
+        submission._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES, seconds=-1)
 
         assert not outdated(submission)
 
@@ -3048,7 +3070,8 @@ class TestOutdated:
         """Ungraded submissions (None grade) should refresh"""
         submission = MagicMock()
         submission.grade = None
-        submission._fetched_at = datetime.now() - timedelta(minutes=6)
+        submission._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
 
         assert outdated(submission)
 
@@ -3056,7 +3079,8 @@ class TestOutdated:
         """Empty grade string should refresh if old"""
         submission = MagicMock()
         submission.grade = ""
-        submission._fetched_at = datetime.now() - timedelta(minutes=10)
+        submission._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
 
         assert outdated(submission)
 
@@ -3064,7 +3088,8 @@ class TestOutdated:
         """Numeric grades (improvable) should refresh if old"""
         submission = MagicMock()
         submission.grade = "85"
-        submission._fetched_at = datetime.now() - timedelta(minutes=7)
+        submission._fetched_at = datetime.now() - timedelta(
+            minutes=SUBMISSION_TTL_MINUTES + 1)
 
         assert outdated(submission)
 @
@@ -3691,8 +3716,8 @@ Key design decisions:
   We track these and trigger refresh only when they're accessed.
 \item[Final grade policy] Submissions with final grades (A, P, P+, complete)
   are never refreshed, maintaining the existing [[NOREFRESH_GRADES]] policy.
-\item[Time-based staleness] We use the existing [[outdated()]] function
-  with 5-minute TTL for non-final grades.
+\item[Time-based staleness] We apply the same time-to-live as [[outdated()]],
+  the [[SUBMISSION_TTL_MINUTES]] constant, for non-final grades.
 \item[Preserved includes] The wrapper stores the original [[include]]
   parameters from [[get_submissions()]] to ensure refreshes request the
   same data.
@@ -3769,6 +3794,13 @@ than a short time-to-live.  A \emph{final} grade never changes, so we skip the
 refresh entirely---this is the [[NOREFRESH_GRADES]] policy, and it is what keeps
 a fully graded course from re-fetching every submission on access.
 
+The time-to-live is [[SUBMISSION_TTL_MINUTES]], the same constant that drives
+[[outdated()]] and the staleness log messages, so all three agree on how long a
+non-final submission stays fresh.  Reading the constant here (rather than a
+literal) is what makes the [[CANVASLMS_SUBMISSION_TTL_MINUTES]] override
+(\cref{sec:cache-ttl-constants}) actually take effect on the live submission
+cache.
+
 <<LazySubmission methods>>=
 def _needs_refresh(self):
   """Check if the wrapped submission needs refreshing."""
@@ -3779,8 +3811,7 @@ def _needs_refresh(self):
   if submission.grade in NOREFRESH_GRADES:
     return False
 
-  # Check time-based staleness (5-minute TTL for non-final grades)
-  if datetime.now() - last_refresh > timedelta(minutes=5):
+  if datetime.now() - last_refresh > timedelta(minutes=SUBMISSION_TTL_MINUTES):
     return True
 
   return False
@@ -3832,12 +3863,12 @@ class TestLazySubmissionStaleness:
 
     def test_would_need_refresh_detects_staleness(self):
         """A stale, non-final submission reports it would refresh."""
-        lazy = self.wrap(grade="F", age_minutes=10)
+        lazy = self.wrap(grade="F", age_minutes=SUBMISSION_TTL_MINUTES + 1)
         assert lazy.would_need_refresh() is True
 
     def test_final_grade_never_needs_refresh(self):
         """Final grades are never stale, even when old."""
-        lazy = self.wrap(grade="P", age_minutes=10)
+        lazy = self.wrap(grade="P", age_minutes=SUBMISSION_TTL_MINUTES + 1)
         assert lazy.would_need_refresh() is False
 @
 
@@ -3888,7 +3919,8 @@ class TestLazySubmissionNormalization:
         lazy = LazySubmission(
             self.StandInSubmission("F"), MagicMock(), set(), refresh)
         object.__setattr__(
-            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
+            lazy, "_last_refresh",
+            datetime.now() - timedelta(minutes=SUBMISSION_TTL_MINUTES + 1))
 
         lazy.ensure_attrs(["grade", "missing_field"])
 
@@ -4128,7 +4160,8 @@ class TestLazySubmissionAssignmentSurvivesRefresh:
         lazy.assignment = sentinel_assignment
         # ... but the wrapper is stale, so the next mutable read refreshes.
         object.__setattr__(
-            lazy, "_last_refresh", datetime.now() - timedelta(minutes=10))
+            lazy, "_last_refresh",
+            datetime.now() - timedelta(minutes=SUBMISSION_TTL_MINUTES + 1))
 
         # Touching a mutable attribute swaps in `fresh`, dropping `.assignment`.
         lazy.submission_history


### PR DESCRIPTION
- **Prefetch submissions in bulk for results summary paths**
- **Make cache TTLs env-overridable and extend submission TTL**
- **Scope students to their course round in results summaries**
