### PR TITLE
Fix silent grade mishandling in maxgradesurvey and tilkryLAB1

### DIFF
--- a/src/canvaslms/cli/utils.nw
+++ b/src/canvaslms/cli/utils.nw
@@ -63,6 +63,7 @@ ASSIGNMENT_ATTRS = (
     "submission_types",
     "submissions_download_url",
     "points_possible",
+    "grading_type",
     "published",
 )
 

--- a/src/canvaslms/grades/maxgradesurvey.nw
+++ b/src/canvaslms/grades/maxgradesurvey.nw
@@ -409,54 +409,178 @@ def test_only_survey_done_yields_f():
 
 \subsection{Finding missing assignments}
 
-Like [[disjunctmax]], this module uses disjunctive grading: a student only needs
-ONE passing grade.
-The semantics of \enquote{missing} are the same:
+For graded assignments the semantics of \enquote{missing} are the same as
+in [[disjunctmax]]: a student only needs ONE passing grade, so
 \begin{itemize}
-\item If the student has at least one passing grade, nothing is missing.
-\item If the student has no passing grades, all assignments are reported as
-  options.
+\item if the student has at least one passing grade among the graded
+  assignments, no graded assignment is missing;
+\item if the student has no passing grade, all graded assignments are
+  reported as options.
 \end{itemize}
+Surveys follow the opposite, conjunctive rule: every uncompleted survey is
+missing, \emph{regardless} of the student's grades.
+An earlier version ignored surveys here, which contradicted [[summarize]]:
+a student with a passing grade but an uncompleted survey was reported as
+having nothing missing, while their summarized grade was F.
 
-The key difference from [[disjunctmax]] is that grades again pass through
+Surveys never count towards the passing check.
+[[normalize_survey_grade]] maps survey scores to F anyway, so this only
+matters if a survey somehow carried a letter grade---and counting that
+would let survey participation substitute for graded work, for the same
+reason we don't map \enquote{complete} to P above.
+As in the other grade modules, grades pass through
 [[normalize_survey_grade]]: P+ counts as P, unrecognized grades as F.
-This accommodates surveys where numeric scores don't count as grades.
 <<helper functions>>=
 def missing_assignments(assignments_list, users_list,
                         passing_regex=None,
                         optional_assignments=None):
   """
-  Returns missing assignments for disjunctive maximum grading with surveys.
+  Returns missing assignments for disjunctive maximum grading with
+  mandatory surveys.
 
-  Only reports assignments if the student has NO passing grades.
-  P+ counts as P; unrecognized grades are treated as F.
+  Reports every uncompleted survey. Reports graded assignments only if
+  the student has no passing grade among them; P+ counts as P,
+  unrecognized grades are treated as F.
   """
   import re
 
   for user in users_list:
-    grades_with_assignments = []
+    <<partition [[user]]'s assignments into graded and undone surveys>>
+    <<report undone surveys>>
+    <<report graded assignments if none passes>>
+@
 
-    # First pass: collect all grades
-    for assignment in assignments_list:
-      # Skip optional assignments
-      if optional_assignments:
-        if any(re.search(opt, assignment.name) for opt in optional_assignments):
-          continue
+We make one pass over the assignments, skipping optional ones, and classify
+each with [[is_survey]].
+For a survey we only need its completion; for a graded assignment we need
+the normalized grade.
+Both cases share the submission lookup, where a missing submission maps to
+[[None]] so that [[survey_completed]] and [[normalize_survey_grade]] treat
+it as uncompleted and F, respectively.
+<<partition [[user]]'s assignments into graded and undone surveys>>=
+graded_grades = []
+undone_surveys = []
 
-      try:
-        submission = assignment.get_submission(user)
-        grade = normalize_survey_grade(submission.grade)
-      except ResourceDoesNotExist:
-        grade = "F"
+for assignment in assignments_list:
+  if optional_assignments:
+    if any(re.search(opt, assignment.name)
+           for opt in optional_assignments):
+      continue
 
-      grades_with_assignments.append((assignment, grade))
+  try:
+    submission = assignment.get_submission(user)
+  except ResourceDoesNotExist:
+    submission = None
 
-    # Check if student has at least one passing grade (P or better)
-    has_passing = any(grade_max([g]) != "F" for _, g in grades_with_assignments)
+  if is_survey(assignment):
+    if not survey_completed(submission):
+      undone_surveys.append(assignment)
+  else:
+    grade = normalize_survey_grade(
+      submission.grade if submission else None)
+    graded_grades.append((assignment, grade))
+@
 
-    if not has_passing:
-      # Report all assignments as options to complete
-      for assignment, grade in grades_with_assignments:
-        yield user, assignment, \
-              f"not a passing grade ({grade}) - complete any one to pass"
+Every uncompleted survey is reported, before and independently of the
+graded assignments: completing it is mandatory even for a student who
+already passed.
+<<report undone surveys>>=
+for assignment in undone_surveys:
+  yield user, assignment, "mandatory survey not completed"
+@
+
+The graded assignments keep the disjunctive rule: only when no graded
+assignment passes do we report them, all of them, as options.
+<<report graded assignments if none passes>>=
+has_passing = any(grade_max([g]) != "F" for _, g in graded_grades)
+
+if not has_passing:
+  for assignment, grade in graded_grades:
+    yield user, assignment, \
+          f"not a passing grade ({grade}) - complete any one to pass"
+@
+
+Let's verify that the two rules combine correctly, reusing the fakes from
+the [[summarize]] tests.
+The regression that motivated the survey rule: a passing grade must not
+hide an uncompleted survey.
+<<test functions>>=
+def test_undone_survey_reported_despite_passing_grade():
+  passing = fake_assignment(
+    "letter_grade",
+    fake_submission("A", submitted_at="2026-05-01T10:00:00Z"))
+  survey = fake_assignment("points", missing=True)
+
+  rows = list(maxgradesurvey.missing_assignments(
+    [passing, survey], ["user"]))
+
+  assert len(rows) == 1
+  user, assignment, reason = rows[0]
+  assert assignment is survey
+  assert "survey" in reason
+
+
+def test_nothing_missing_when_passing_and_survey_done():
+  passing = fake_assignment(
+    "letter_grade",
+    fake_submission("A", submitted_at="2026-05-01T10:00:00Z"))
+  survey = fake_assignment(
+    "points",
+    fake_submission("17.0", submitted_at="2026-05-02T10:00:00Z"))
+
+  rows = list(maxgradesurvey.missing_assignments(
+    [passing, survey], ["user"]))
+
+  assert rows == []
+@
+
+Without a passing grade, both rules fire: the survey is reported as
+mandatory and every graded assignment as an option.
+<<test functions>>=
+def test_all_reported_when_no_passing_grade():
+  failed = fake_assignment(
+    "letter_grade",
+    fake_submission("F", submitted_at="2026-05-01T10:00:00Z"))
+  unattempted = fake_assignment("letter_grade", missing=True)
+  survey = fake_assignment("points", missing=True)
+
+  rows = list(maxgradesurvey.missing_assignments(
+    [failed, unattempted, survey], ["user"]))
+
+  assert len(rows) == 3
+  reported = [assignment for _, assignment, _ in rows]
+  assert survey in reported
+  assert failed in reported
+  assert unattempted in reported
+@
+
+Optional assignments are skipped before classification, so even an
+uncompleted survey is not demanded when it matches the optional pattern.
+And the survey's own score never counts as passing: a student who only
+completed the survey still has all graded assignments reported.
+<<test functions>>=
+def test_optional_survey_not_required():
+  passing = fake_assignment(
+    "letter_grade",
+    fake_submission("A", submitted_at="2026-05-01T10:00:00Z"))
+  survey = fake_assignment("points", missing=True,
+                           name="Optional survey")
+
+  rows = list(maxgradesurvey.missing_assignments(
+    [passing, survey], ["user"], optional_assignments=["Optional"]))
+
+  assert rows == []
+
+
+def test_survey_grade_never_passes():
+  unattempted = fake_assignment("letter_grade", missing=True)
+  survey = fake_assignment(
+    "points",
+    fake_submission("17.0", submitted_at="2026-05-02T10:00:00Z"))
+
+  rows = list(maxgradesurvey.missing_assignments(
+    [unattempted, survey], ["user"]))
+
+  assert len(rows) == 1
+  assert rows[0][1] is unattempted
 

--- a/src/canvaslms/grades/maxgradesurvey.nw
+++ b/src/canvaslms/grades/maxgradesurvey.nw
@@ -1,14 +1,25 @@
 \section{Maximum grade, latest date with surveys, the \texttt{maxgradesurvey} 
 module}
 
-In this module we want to provide the disjunctive maximum way of computing 
+In this module we want to provide the disjunctive maximum way of computing
 \emph{one grade} from \emph{several assignments}.
-But we also want to include ungraded surveys.
+But we also want to include surveys, which are mandatory.
+This gives the module two independent rules:
+\begin{enumerate}
+\item Graded assignments combine by \emph{disjunctive maximum}: one passing
+  grade suffices, the remaining graded assignments may be failed or not
+  attempted at all.
+\item Every survey is \emph{mandatory}: it must be completed, and an
+  uncompleted survey blocks the grade.
+\end{enumerate}
+Surveys carry no letter grade (typically a quiz with points, where the
+number of points is ignored), so they can never contribute a passing grade;
+their only contribution is their completion---and their date.
 <<module doc>>=
-Module that summarizes an assignment group by maximizing grade and date. This 
-module is the same as `canvaslms.grades.disjunctmax`, but also includes 
-ungraded surveys (for instance quiz with points, where the number of points is 
-ignored). Consequently all assignments must have a date.
+Module that summarizes an assignment group by maximizing grade and date.
+Graded assignments combine as in `canvaslms.grades.disjunctmax`: one passing
+grade suffices. Surveys (assignments graded in points, not letter grades)
+are mandatory: each must be completed, but their scores are ignored.
 
 This function also doesn't fail when there is a grade other than A--F or P/F
 present. P+ counts as P; all other unrecognized grades (for instance numeric
@@ -46,6 +57,11 @@ We define the test file structure early, but place each test after the
 functionality it verifies.
 <<test [[maxgradesurvey.py]]>>=
 """Tests for the canvaslms.grades.maxgradesurvey module."""
+import datetime as dt
+from types import SimpleNamespace
+
+from canvasapi.exceptions import ResourceDoesNotExist
+
 import canvaslms.grades.maxgradesurvey as maxgradesurvey
 
 <<test functions>>
@@ -113,61 +129,281 @@ def test_unrecognized_grades_become_f():
 @
 
 
+\subsection{Telling surveys from graded assignments}
+
+The two rules from the introduction treat surveys and graded assignments
+differently, so we must classify each assignment.
+What distinguishes a survey is its grading scheme: graded assignments use a
+letter-grade scheme (A--F or P/F), while surveys are graded in points only.
+Canvas exposes the scheme as the assignment's [[grading_type]]: the
+letter-grade schemes are [[letter_grade]] and its GPA variant [[gpa_scale]].
+The points-only schemes ([[points]], [[percent]] and friends) can never
+produce a grade that [[grade_max]] can rank, so such an assignment's only
+meaningful contribution is its completion.
+
+We classify by set membership against the letter-grade schemes and treat
+everything else as a survey.
+The direction of this default is deliberate.
+Misclassifying a graded assignment as a survey is mostly harmless: its grade
+still feeds the maximum, we merely also require completion---which a graded
+submission has.
+Misclassifying a survey as graded, however, would silently drop the
+mandatory-survey rule.
+Hence an unknown or missing [[grading_type]] classifies as survey.
+We keep the classification in one small predicate so the detection strategy
+stays swappable.
+<<helper functions>>=
+LETTER_GRADING_TYPES = {"letter_grade", "gpa_scale"}
+
+def is_survey(assignment):
+  """True iff the assignment is a survey (points only, no letter grades)."""
+  return assignment.grading_type not in LETTER_GRADING_TYPES
+@
+
+Let's verify that the letter-grade schemes classify as graded assignments
+and that everything else---including a missing grading type---classifies as
+a survey.
+<<test functions>>=
+def test_letter_grading_types_are_not_surveys():
+  for grading_type in ["letter_grade", "gpa_scale"]:
+    assert not maxgradesurvey.is_survey(
+      SimpleNamespace(grading_type=grading_type))
+
+
+def test_other_grading_types_are_surveys():
+  for grading_type in ["points", "percent", "complete_incomplete",
+                       "not_graded", None]:
+    assert maxgradesurvey.is_survey(
+      SimpleNamespace(grading_type=grading_type))
+@
+
+Both [[summarize]] and [[missing_assignments]] must agree on what it means
+for a survey to be completed, so we define completion once.
+The evidence of completion is a date: a survey the student submitted has
+[[submitted_at]], and one a teacher marked manually has [[graded_at]].
+Accepting [[None]] lets call sites map a missing submission
+([[ResourceDoesNotExist]]) to \enquote{not completed} without duplicating
+the rule.
+<<helper functions>>=
+def survey_completed(submission):
+  """True iff the submission shows the survey was completed.
+
+  Pass None (no submission exists) for not completed.
+  """
+  if submission is None:
+    return False
+  return bool(submission.submitted_at or submission.graded_at)
+@
+
+A survey counts as completed with either date, and as uncompleted with
+neither date---or with no submission at all.
+<<test functions>>=
+def test_survey_completed_by_submission_date():
+  assert maxgradesurvey.survey_completed(
+    SimpleNamespace(submitted_at="2026-07-01T10:00:00Z", graded_at=None))
+
+
+def test_survey_completed_by_grading_date():
+  assert maxgradesurvey.survey_completed(
+    SimpleNamespace(submitted_at=None, graded_at="2026-07-01T10:00:00Z"))
+
+
+def test_survey_without_dates_not_completed():
+  assert not maxgradesurvey.survey_completed(
+    SimpleNamespace(submitted_at=None, graded_at=None))
+
+
+def test_missing_submission_not_completed():
+  assert not maxgradesurvey.survey_completed(None)
+@
+
+
 \subsection{Summarizing grades: assignment grades to component grade}
 
 Now we will describe the [[summarize]] helper function.
-We want to establish three things: the most recent date, a suitable grade and 
-the graders.
+We want to establish three things: the most recent date, a suitable grade
+and the graders.
 
-For the most recent date, we just add them to a list as we iterate through the 
-submissions.
+For the most recent date, we just add them to a list as we iterate through
+the submissions.
 We do the same for grades, as we iterate through we add any grade to a list.
 In the end we compute the maximums of both lists.
+Compared to the [[summarize]] function in \cref{disjunctmax-summarize}, all
+grades pass through [[normalize_survey_grade]] and we additionally track
+whether every survey is completed.
 
-The key difference to the [[summarize]] function in
-\cref{disjunctmax-summarize} is the grade translation through
-[[normalize_survey_grade]].
+The mandatory-survey rule needs care.
+An earlier version enforced it as [[len(dates) < len(grades)]]: every
+assignment contributes a grade, but only submissions with a date contribute
+a date, so any missing date forced the final grade to F.
+That test looks like \enquote{every survey answered}, but it actually
+asserts \enquote{every \emph{assignment} has a date}.
+A graded assignment the student never attempted appends an F with no date
+and trips the veto---even though the disjunctive rule says an unattempted
+graded assignment is fine as long as another one passes.
+A student with an A who skipped a redundant graded assignment was thus
+reported as failing.
+Therefore we test completion per \emph{survey} only, using [[is_survey]]
+and [[survey_completed]]; graded assignments participate only through
+[[grade_max]].
 <<helper functions>>=
 def summarize(user, assignments_list):
-  """Extracts user's submissions for assignments in assingments_list to 
-  summarize results into one grade and a grade date. Summarize by disjunctive 
-  maximum."""
+  """Extracts user's submissions for assignments in assingments_list to
+  summarize results into one grade and a grade date. Graded assignments
+  summarize by disjunctive maximum; every survey must be completed."""
 
   grades = []
   dates = []
   graders = []
+  surveys_done = True
 
   for assignment in assignments_list:
-    try:
-      submission = assignment.get_submission(user,
-                                             include=["submission_history"])
-    except ResourceDoesNotExist:
-      grades.append("F")
-      continue
+    <<collect grade, date and survey completion from one submission>>
 
-    submission.assignment = assignment
-    graders += results.all_graders(submission)
-
-    grades.append(normalize_survey_grade(submission.grade))
-
-    grade_date = submission.submitted_at or submission.graded_at
-
-    if grade_date:
-      grade_date = dt.date.fromisoformat(grade_date.split("T")[0])
-      dates.append(grade_date)
-
-  if len(dates) < len(grades):
-    final_grade = "F"
-  else:
-    final_grade = grade_max(grades) or "F"
-
-  if dates:
-    final_date = max(dates)
-  else:
-    final_date = None
-    final_grade = None
+  <<combine collected results into [[final_grade]] and [[final_date]]>>
 
   return (final_grade, final_date, graders)
+@
+
+For each assignment we fetch the user's submission.
+A submission that doesn't exist contributes an F to the maximum; if the
+assignment is a survey, the missing submission also means the survey is
+uncompleted.
+<<collect grade, date and survey completion from one submission>>=
+try:
+  submission = assignment.get_submission(user,
+                                         include=["submission_history"])
+except ResourceDoesNotExist:
+  grades.append("F")
+  if is_survey(assignment):
+    surveys_done = False
+  continue
+
+submission.assignment = assignment
+graders += results.all_graders(submission)
+
+grades.append(normalize_survey_grade(submission.grade))
+
+if is_survey(assignment) and not survey_completed(submission):
+  surveys_done = False
+
+grade_date = submission.submitted_at or submission.graded_at
+
+if grade_date:
+  grade_date = dt.date.fromisoformat(grade_date.split("T")[0])
+  dates.append(grade_date)
+@
+
+If there are no dates at all, the student hasn't done anything; we return
+[[None]] so that the [[results]] command can skip the row entirely.
+Otherwise an uncompleted survey caps the grade at F, and only when all
+surveys are completed do we award the disjunctive maximum.
+<<combine collected results into [[final_grade]] and [[final_date]]>>=
+if not dates:
+  final_grade = None
+  final_date = None
+elif not surveys_done:
+  final_grade = "F"
+  final_date = max(dates)
+else:
+  final_grade = grade_max(grades) or "F"
+  final_date = max(dates)
+@
+
+Let's verify the interplay of the two rules, with fake assignments and
+submissions modelled on the real Canvas objects.
+<<test functions>>=
+def fake_assignment(grading_type, submission=None, missing=False,
+                    name="fake"):
+  """Fake assignment whose get_submission returns submission,
+  or raises ResourceDoesNotExist if missing is True."""
+  def get_submission(user, **kwargs):
+    if missing:
+      raise ResourceDoesNotExist("no submission")
+    return submission
+  return SimpleNamespace(grading_type=grading_type,
+                         name=name,
+                         get_submission=get_submission)
+
+
+def fake_submission(grade, submitted_at=None, graded_at=None):
+  """Fake submission with the attributes summarize reads."""
+  return SimpleNamespace(grade=grade,
+                         submitted_at=submitted_at,
+                         graded_at=graded_at,
+                         submission_history=[])
+@
+
+First the regression that motivated the per-survey test: an A on one graded
+assignment, another graded assignment never attempted, and a completed
+survey must yield the A---not F.
+<<test functions>>=
+def test_skipped_graded_assignment_does_not_veto():
+  assignments = [
+    fake_assignment("letter_grade",
+                    fake_submission("A",
+                                    submitted_at="2026-05-01T10:00:00Z")),
+    fake_assignment("letter_grade", missing=True),
+    fake_assignment("points",
+                    fake_submission("17.0",
+                                    submitted_at="2026-05-02T10:00:00Z")),
+  ]
+  grade, date, graders = maxgradesurvey.summarize("user", assignments)
+  assert grade == "A"
+  assert date == dt.date(2026, 5, 2)
+  assert graders == []
+@
+
+Conversely, an uncompleted survey must block the grade---whether the
+submission is entirely missing or exists without any date.
+<<test functions>>=
+def test_missing_survey_vetoes_grade():
+  assignments = [
+    fake_assignment("letter_grade",
+                    fake_submission("A",
+                                    submitted_at="2026-05-01T10:00:00Z")),
+    fake_assignment("points", missing=True),
+  ]
+  grade, date, _ = maxgradesurvey.summarize("user", assignments)
+  assert grade == "F"
+  assert date == dt.date(2026, 5, 1)
+
+
+def test_dateless_survey_submission_vetoes_grade():
+  assignments = [
+    fake_assignment("letter_grade",
+                    fake_submission("A",
+                                    submitted_at="2026-05-01T10:00:00Z")),
+    fake_assignment("points", fake_submission(None)),
+  ]
+  grade, _, _ = maxgradesurvey.summarize("user", assignments)
+  assert grade == "F"
+@
+
+A student who hasn't done anything yields no grade at all (the row is
+skipped downstream), while a student who only completed the survey gets F:
+the survey score can never pass.
+<<test functions>>=
+def test_nothing_done_yields_no_grade():
+  assignments = [
+    fake_assignment("letter_grade", missing=True),
+    fake_assignment("points", missing=True),
+  ]
+  grade, date, _ = maxgradesurvey.summarize("user", assignments)
+  assert grade is None
+  assert date is None
+
+
+def test_only_survey_done_yields_f():
+  assignments = [
+    fake_assignment("letter_grade", missing=True),
+    fake_assignment("points",
+                    fake_submission("17.0",
+                                    submitted_at="2026-05-02T10:00:00Z")),
+  ]
+  grade, date, _ = maxgradesurvey.summarize("user", assignments)
+  assert grade == "F"
+  assert date == dt.date(2026, 5, 2)
 @
 
 

--- a/src/canvaslms/grades/maxgradesurvey.nw
+++ b/src/canvaslms/grades/maxgradesurvey.nw
@@ -10,8 +10,9 @@ module is the same as `canvaslms.grades.disjunctmax`, but also includes
 ungraded surveys (for instance quiz with points, where the number of points is 
 ignored). Consequently all assignments must have a date.
 
-This function also doen't fail when there is a grade other than A--F or P/F 
-present. Such grades are all treated as F.
+This function also doesn't fail when there is a grade other than A--F or P/F
+present. P+ counts as P; all other unrecognized grades (for instance numeric
+survey scores) are treated as F.
 @
 
 We have one requirement on the summary module: it must contain a function 
@@ -41,6 +42,76 @@ def summarize_group(assignments_list, users_list):
     yield [user, grade, grade_date, *graders]
 @
 
+We define the test file structure early, but place each test after the
+functionality it verifies.
+<<test [[maxgradesurvey.py]]>>=
+"""Tests for the canvaslms.grades.maxgradesurvey module."""
+import canvaslms.grades.maxgradesurvey as maxgradesurvey
+
+<<test functions>>
+@
+
+
+\subsection{Normalizing grades for survey-inclusive grading}
+
+This module's defining trait is that unrecognized grades---numeric survey
+scores, for instance---count as F instead of crashing the summary.
+That translation used to be inlined as
+[[grade not in "ABCDEPF"]], which has two flaws.
+First, it is a \emph{substring} test, not a membership test: the empty
+string and two-letter fragments like \enquote{EP} count as valid grades,
+only to crash later with a [[KeyError]] inside [[grade_max]].
+Second, it silently downgraded P+ to F.
+P+ is a first-class passing grade elsewhere in canvaslms (the cache
+treats it as final, and [[tilkryLAB1]] maps it to P), so a student whose
+passing grade was P+ would be reported as \emph{failing}, with no
+warning.
+
+We centralize the translation in one helper: set membership against the
+grades [[grade_max]] can rank, with P+ normalized to P first.
+
+We deliberately do \emph{not} map Canvas's \enquote{complete} to P, even
+though the [[results]] command counts it as passing elsewhere: surveys in
+these assignment groups commonly auto-record completion, and under
+disjunctive grading a complete-counts-as-P rule would pass a student on
+survey participation alone.
+Such grades stay F here; a course where \enquote{complete} is a real
+grade needs its own summary module.
+<<helper functions>>=
+RECOGNIZED_GRADES = {"A", "B", "C", "D", "E", "P", "F"}
+
+def normalize_survey_grade(grade):
+  """Normalize a Canvas grade for survey-inclusive grading.
+
+  P+ counts as P. Any grade not recognized by grade_max
+  (e.g. None or a numeric survey score) is treated as F.
+  """
+  if grade == "P+":
+    return "P"
+  if grade in RECOGNIZED_GRADES:
+    return grade
+  return "F"
+@
+
+Let's verify the three behaviours: P+ passes, recognized grades pass
+through untouched, and everything else---including the substring-test
+false positives---becomes F.
+
+<<test functions>>=
+def test_p_plus_normalizes_to_p():
+  assert maxgradesurvey.normalize_survey_grade("P+") == "P"
+
+
+def test_recognized_grades_pass_through():
+  for grade in ["A", "B", "C", "D", "E", "P", "F"]:
+    assert maxgradesurvey.normalize_survey_grade(grade) == grade
+
+
+def test_unrecognized_grades_become_f():
+  for grade in [None, "", "EP", "17.0", "complete"]:
+    assert maxgradesurvey.normalize_survey_grade(grade) == "F"
+@
+
 
 \subsection{Summarizing grades: assignment grades to component grade}
 
@@ -53,8 +124,9 @@ submissions.
 We do the same for grades, as we iterate through we add any grade to a list.
 In the end we compute the maximums of both lists.
 
-The key difference to the [[summarize]] function in 
-\cref{disjunctmax-summarize} is the translation of other grades to F.
+The key difference to the [[summarize]] function in
+\cref{disjunctmax-summarize} is the grade translation through
+[[normalize_survey_grade]].
 <<helper functions>>=
 def summarize(user, assignments_list):
   """Extracts user's submissions for assignments in assingments_list to 
@@ -76,12 +148,7 @@ def summarize(user, assignments_list):
     submission.assignment = assignment
     graders += results.all_graders(submission)
 
-    grade = submission.grade
-
-    if grade is None or grade not in "ABCDEPF":
-      grade = "F"
-
-    grades.append(grade)
+    grades.append(normalize_survey_grade(submission.grade))
 
     grade_date = submission.submitted_at or submission.graded_at
 
@@ -115,8 +182,8 @@ The semantics of \enquote{missing} are the same:
   options.
 \end{itemize}
 
-The key difference from [[disjunctmax]] is that unknown grades (grades not in
-A--F or P) are treated as F.
+The key difference from [[disjunctmax]] is that grades again pass through
+[[normalize_survey_grade]]: P+ counts as P, unrecognized grades as F.
 This accommodates surveys where numeric scores don't count as grades.
 <<helper functions>>=
 def missing_assignments(assignments_list, users_list,
@@ -126,7 +193,7 @@ def missing_assignments(assignments_list, users_list,
   Returns missing assignments for disjunctive maximum grading with surveys.
 
   Only reports assignments if the student has NO passing grades.
-  Unknown grades (not A-F or P) are treated as F.
+  P+ counts as P; unrecognized grades are treated as F.
   """
   import re
 
@@ -142,10 +209,7 @@ def missing_assignments(assignments_list, users_list,
 
       try:
         submission = assignment.get_submission(user)
-        grade = submission.grade
-        # Unknown grades are treated as F
-        if grade is None or grade not in "ABCDEPF":
-          grade = "F"
+        grade = normalize_survey_grade(submission.grade)
       except ResourceDoesNotExist:
         grade = "F"
 

--- a/src/canvaslms/grades/tilkryLAB1.nw
+++ b/src/canvaslms/grades/tilkryLAB1.nw
@@ -283,12 +283,17 @@ If there is no grade or submission, we'll treat it as an F.
 
 We also added a grade P+, for the fun of it, on one assignment.
 We treat it as a normal P though.
+
+Note that the validity check must be set membership, not
+[[grade not in "PF"]]: the latter is a \emph{substring} test, so an
+empty-string grade would slip through as \enquote{valid} instead of
+being warned about and turned into F.
 <<handle mandatory>>=
 if grade is None:
   grade = "F"
 elif grade == "P+":
   grade = "P"
-elif grade not in "PF":
+elif grade not in {"P", "F"}:
   logging.warning(f"Invalid grade {grade} for {user} in {assignment}, "
                   "using F")
   grade = "F"


### PR DESCRIPTION
## Summary

Found by a review sweep of the grading modules, then extended after a
semantics review of `maxgradesurvey` (see below).

**maxgradesurvey silently downgraded P+ (a passing grade) to F.** The inline
check `grade not in "ABCDEPF"` treated any unlisted grade as F by design (to
absorb numeric survey scores), but P+ is a first-class passing grade elsewhere
in canvaslms (`NOREFRESH_GRADES`, `tilkryLAB1` maps it to P) — so a student
whose passing grade was P+ was reported as *failing*, with no warning.

The check was also a *substring* test, not membership: `""` and fragments like
`"EP"` counted as "valid" grades, only to crash later with `KeyError` inside
`grade_max`.

Both flaws are fixed by centralizing translation in a new
`normalize_survey_grade()`: set membership against the grades `grade_max` can
rank, with P+ normalized to P first. Canvas's `complete` deliberately stays F —
surveys in these assignment groups auto-record completion, and a
complete-counts-as-P rule would pass a student on survey participation alone
under disjunctive grading (rationale documented in the literate prose).

**tilkryLAB1 had the same substring flaw** (`grade not in "PF"`): an
empty-string grade slipped through as valid instead of being warned about and
treated as F. Now tests against `{"P", "F"}`.

## Survey semantics fixes (added after review)

`maxgradesurvey`'s intended semantics are two independent rules: graded
assignments combine by disjunctive maximum (one passing grade suffices), and
every survey is mandatory. Two bugs against those semantics:

**The date test vetoed skipped graded assignments.** `summarize` enforced the
mandatory-survey rule as `len(dates) < len(grades)`, which demands a date for
*every* assignment — so a student with an A who legitimately skipped another
*graded* assignment was forced to F. Assignments are now classified with a new
`is_survey()` (`grading_type` not a letter-grade scheme, i.e. points-only ⇒
survey), and only surveys must show completion (`survey_completed()`: a
`submitted_at` or `graded_at` date).

**`missing_assignments` never checked survey completion**: a student with a
passing grade but an undone survey was reported as having nothing missing,
while `summarize` simultaneously gave them F. It now reports every uncompleted
survey regardless of grades ("mandatory survey not completed"); graded
assignments keep the disjunctive all-or-nothing report among themselves, and
survey scores never count toward passing.

Supporting change: `grading_type` added to the centralized
`ASSIGNMENT_ATTRS` in `utils.nw` (no cache schema bump needed — cached
pickles already carry the attribute).

Follow-up: PR reusing `is_survey`/`survey_completed` in `conjunctavgsurvey`
(#339) is stacked on this branch.

## Test plan

- [x] 3 tests for `normalize_survey_grade` (P+ → P, recognized grades pass through, `None`/`""`/`"EP"`/numeric/`complete` → F)
- [x] 16 further tests: `is_survey`, `survey_completed`, `summarize` (incl. regression: A + skipped graded assignment + completed survey ⇒ A; undone survey ⇒ F), `missing_assignments` (incl. regression: passing grade + undone survey ⇒ survey reported)
- [x] Full tangled suite passes (354 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lz1Ft1GN2YqQ6YGLGVYZdT

https://claude.ai/code/session_01DjzjbfTB6tXiF7hoTV8XH4