### PR TITLE
Fall back to defaults for malformed tuning env vars

### DIFF
--- a/src/canvaslms/hacks/canvasapi.nw
+++ b/src/canvaslms/hacks/canvasapi.nw
@@ -27,6 +27,7 @@ import sys
 
 logger = logging.getLogger(__name__)
 
+<<environment helpers>>
 <<constants>>
 <<functions>>
 
@@ -93,6 +94,8 @@ IMPORTANT: These tests import canvaslms.hacks.canvasapi, which applies
 monkey-patches to canvasapi classes. The patches are applied at import
 time and affect all future instances.
 """
+import logging
+
 import pytest
 from unittest.mock import MagicMock
 from datetime import datetime, timedelta
@@ -2831,7 +2834,55 @@ except AttributeError:
   return True
 @
 
-Instinctively, we might want to use all passing grades as the grades that don't 
+Several of the tuning constants below can be overridden through
+environment variables.
+A bare [[int()]] or [[float()]] of the environment value would let a
+malformed variable---say [[CANVASLMS_SUBMISSION_TTL_MINUTES=off]]---raise
+[[ValueError]] at import time, aborting \emph{every} subcommand (even
+[[--help]]) with a raw traceback.
+A tuning knob must not be able to brick the CLI, so we read these values
+through a helper that falls back to the default with a warning instead.
+The helper tangles into the module before the constants (see the module
+outline), since the constants call it at import time.
+<<environment helpers>>=
+def env_number(name, default, parse):
+  """Read the numeric setting `name` from the environment.
+
+  Converts with `parse` (int or float); falls back to `default`,
+  with a warning, if the variable is set but doesn't parse.
+  """
+  value = os.environ.get(name)
+  if value is None:
+    return default
+  try:
+    return parse(value)
+  except ValueError:
+    logger.warning(f"ignoring {name}={value!r}: "
+                   f"not a number, using default {default}")
+    return default
+@
+
+Let's verify the three cases: unset, well-formed and malformed.
+
+<<test functions>>=
+def test_env_number_defaults_when_unset(monkeypatch):
+  monkeypatch.delenv("CANVASLMS_TEST_KNOB", raising=False)
+  assert env_number("CANVASLMS_TEST_KNOB", 20, int) == 20
+
+
+def test_env_number_parses_set_value(monkeypatch):
+  monkeypatch.setenv("CANVASLMS_TEST_KNOB", "0.5")
+  assert env_number("CANVASLMS_TEST_KNOB", 0.2, float) == 0.5
+
+
+def test_env_number_falls_back_on_malformed_value(monkeypatch, caplog):
+  monkeypatch.setenv("CANVASLMS_TEST_KNOB", "off")
+  with caplog.at_level(logging.WARNING):
+    assert env_number("CANVASLMS_TEST_KNOB", 20, int) == 20
+  assert "CANVASLMS_TEST_KNOB" in caplog.text
+@
+
+Instinctively, we might want to use all passing grades as the grades that don't
 need refreshing.
 However, even if a student has gotten a B, they might want to improve their 
 grade.
@@ -2842,8 +2893,8 @@ NOREFRESH_GRADES = ["A", "P", "P+", "complete"]
 
 # Threshold for bulk refresh optimization
 # Can be overridden via environment variables
-BULK_REFRESH_THRESHOLD = float(os.environ.get('CANVASLMS_BULK_THRESHOLD', '0.2'))
-BULK_REFRESH_MIN_COUNT = int(os.environ.get('CANVASLMS_BULK_MIN_COUNT', '3'))
+BULK_REFRESH_THRESHOLD = env_number('CANVASLMS_BULK_THRESHOLD', 0.2, float)
+BULK_REFRESH_MIN_COUNT = env_number('CANVASLMS_BULK_MIN_COUNT', 3, int)
 @
 
 \label{sec:cache-ttl-constants}
@@ -2863,16 +2914,16 @@ rather than re-fetching every in-progress submission, while final grades in
 [[NOREFRESH_GRADES]] stay cached regardless.
 <<constants>>=
 # Cache TTL constants (overridable via environment)
-SUBMISSION_TTL_MINUTES = int(
-  os.environ.get("CANVASLMS_SUBMISSION_TTL_MINUTES", "20"))
-DEFAULT_CACHE_TTL_DAYS = int(
-  os.environ.get("CANVASLMS_DEFAULT_CACHE_TTL_DAYS", "7"))
-USER_CACHE_TTL_DAYS = int(
-  os.environ.get("CANVASLMS_USER_CACHE_TTL_DAYS", "2"))
-GROUP_CACHE_TTL_DAYS = int(
-  os.environ.get("CANVASLMS_GROUP_CACHE_TTL_DAYS", "5"))
-QUIZ_CACHE_TTL_DAYS = int(
-  os.environ.get("CANVASLMS_QUIZ_CACHE_TTL_DAYS", "3"))
+SUBMISSION_TTL_MINUTES = env_number(
+  "CANVASLMS_SUBMISSION_TTL_MINUTES", 20, int)
+DEFAULT_CACHE_TTL_DAYS = env_number(
+  "CANVASLMS_DEFAULT_CACHE_TTL_DAYS", 7, int)
+USER_CACHE_TTL_DAYS = env_number(
+  "CANVASLMS_USER_CACHE_TTL_DAYS", 2, int)
+GROUP_CACHE_TTL_DAYS = env_number(
+  "CANVASLMS_GROUP_CACHE_TTL_DAYS", 5, int)
+QUIZ_CACHE_TTL_DAYS = env_number(
+  "CANVASLMS_QUIZ_CACHE_TTL_DAYS", 3, int)
 @
 
 Some query arguments are additive, such as [[include]], and fit naturally in a


### PR DESCRIPTION
## Summary

Found by a review sweep of the cache layer. The TTL and bulk-refresh
constants parsed their `CANVASLMS_*` environment overrides with bare
`int()`/`float()` at import time, so a malformed value — say
`CANVASLMS_SUBMISSION_TTL_MINUTES=off` — crashed **every** subcommand
(including `--help`) with a raw `ValueError` traceback, making the tool
unusable until the variable was unset.

All seven env-overridable numbers now go through a new `env_number()` helper
that warns and falls back to the default when the value doesn't parse:

```
$ CANVASLMS_SUBMISSION_TTL_MINUTES=off canvaslms courses -h
ignoring CANVASLMS_SUBMISSION_TTL_MINUTES='off': not a number, using default 20
(help output follows, exit 0)
```

## Test plan

- [x] 3 new tests (unset → default, set → parsed, malformed → default + warning); test_hacks suite 142/142
- [x] End-to-end: malformed env var warns and continues; well-formed override still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lz1Ft1GN2YqQ6YGLGVYZdT